### PR TITLE
fix: Accept `dfx` cache path as CLI arg instead of relying on finding first `dfx` in `$PATH`

### DIFF
--- a/extensions-utils/src/download_wasms/nns.rs
+++ b/extensions-utils/src/download_wasms/nns.rs
@@ -1,8 +1,7 @@
 //! Information about, and utils for canisters deployed via `ic nns install`.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
-use dfx_core::config::cache::{get_bin_cache, Cache};
 use fn_error_context::context;
 
 use crate::{download_ic_repo_wasm, replica_rev};
@@ -11,13 +10,13 @@ use super::sns::download_sns_wasms;
 
 /// Downloads all the core NNS wasms, excluding only the front-end wasms II and NNS-dapp.
 #[context("Failed to download NNS wasm files.")]
-pub async fn download_nns_wasms(cache: &dyn Cache) -> anyhow::Result<()> {
+pub async fn download_nns_wasms(dfx_cache_path: &Path) -> anyhow::Result<()> {
     let ic_commit = if let Ok(env_ic_commit) = std::env::var("DFX_IC_COMMIT") {
         env_ic_commit
     } else {
-        replica_rev()?
+        replica_rev(dfx_cache_path)?
     };
-    let wasm_dir = &nns_wasm_dir(cache)?;
+    let wasm_dir = &nns_wasm_dir(dfx_cache_path);
     for IcNnsInitCanister {
         wasm_name,
         test_wasm_name,
@@ -34,8 +33,8 @@ pub async fn download_nns_wasms(cache: &dyn Cache) -> anyhow::Result<()> {
 }
 
 /// The local directory where NNS wasm files are cached.  The directory is typically created on demand.
-pub fn nns_wasm_dir(cache: &dyn Cache) -> anyhow::Result<PathBuf> {
-    Ok(get_bin_cache(&cache.version_str())?.join("wasms"))
+pub fn nns_wasm_dir(dfx_cache_path: &Path) -> PathBuf {
+    dfx_cache_path.join("wasms")
 }
 
 /// Configuration for an NNS canister installation as performed by `ic-nns-init`.
@@ -89,7 +88,7 @@ pub const NNS_CYCLES_MINTING: IcNnsInitCanister = IcNnsInitCanister {
 /// Canister used to restore functionality in an emergency.
 pub const NNS_LIFELINE: IcNnsInitCanister = IcNnsInitCanister {
     canister_name: "nns-lifeline",
-    wasm_name: "lifeline.wasm",
+    wasm_name: "lifeline_canister.wasm",
     test_wasm_name: None,
     canister_id: "rno2w-sqaaa-aaaaa-aaacq-cai",
 };

--- a/extensions-utils/src/lib.rs
+++ b/extensions-utils/src/lib.rs
@@ -6,7 +6,7 @@ mod error;
 mod logger;
 mod project;
 
-pub use dfx::{call_bundled, dfx_version, replica_rev, webserver_port, Cache};
+pub use dfx::{call_bundled, dfx_version, replica_rev, webserver_port};
 pub use download_wasms::download_ic_repo_wasm;
 pub use download_wasms::nns::download_nns_wasms;
 pub use download_wasms::nns::{

--- a/extensions/nns/src/commands/import.rs
+++ b/extensions/nns/src/commands/import.rs
@@ -1,5 +1,5 @@
 //! Code for the command line: `dfx nns import`
-use std::collections::BTreeMap;
+use std::{collections::BTreeMap, path::Path};
 
 use dfx_core::config::model::canister_id_store::CanisterIds;
 use dfx_core::config::model::dfinity::Config;
@@ -25,7 +25,7 @@ pub struct ImportOpts {
 }
 
 /// Executes `dfx nns import`
-pub async fn exec(opts: ImportOpts) -> anyhow::Result<()> {
+pub async fn exec(opts: ImportOpts, dfx_cache_path: &Path) -> anyhow::Result<()> {
     let config = Config::from_current_dir()?;
     if config.is_none() {
         anyhow::bail!("No config file found. Please run `dfx config create` first.");
@@ -37,7 +37,7 @@ pub async fn exec(opts: ImportOpts) -> anyhow::Result<()> {
     let ic_commit = if let Ok(env_ic_commit) = std::env::var("DFX_IC_COMMIT") {
         env_ic_commit
     } else {
-        replica_rev()?
+        replica_rev(dfx_cache_path)?
     };
     let dfx_url_str = {
         let ic_project = std::env::var("DFX_IC_SRC").unwrap_or_else(|_| {

--- a/extensions/nns/src/install_nns.rs
+++ b/extensions/nns/src/install_nns.rs
@@ -609,6 +609,7 @@ pub async fn install_canister(
 fn bundled_binary(dfx_cache_path: &Path, cli_name: &str) -> anyhow::Result<PathBuf> {
     let bin_path = dfx_cache_path.join(cli_name);
     if !bin_path.exists() {
+        let bin_path = bin_path.to_string_lossy();
         return Err(anyhow::anyhow!(format!(
             "Could not find bundled binary '{bin_path}'."
         )));

--- a/extensions/nns/src/install_nns.rs
+++ b/extensions/nns/src/install_nns.rs
@@ -609,9 +609,9 @@ pub async fn install_canister(
 fn bundled_binary(dfx_cache_path: &Path, cli_name: &str) -> anyhow::Result<PathBuf> {
     let bin_path = dfx_cache_path.join(cli_name);
     if !bin_path.exists() {
-        let bin_path = bin_path.to_string_lossy();
         return Err(anyhow::anyhow!(format!(
-            "Could not find bundled binary '{bin_path}'."
+            "Could not find bundled binary '{bin_path}'.",
+            bin_path = bin_path.display()
         )));
     }
     Ok(bin_path)

--- a/extensions/nns/src/install_nns.rs
+++ b/extensions/nns/src/install_nns.rs
@@ -610,7 +610,7 @@ fn bundled_binary(dfx_cache_path: &Path, cli_name: &str) -> anyhow::Result<PathB
     let bin_path = dfx_cache_path.join(cli_name);
     if !bin_path.exists() {
         return Err(anyhow::anyhow!(format!(
-            "Could not find bundled binary '{cli_name}'."
+            "Could not find bundled binary '{bin_path}'."
         )));
     }
     Ok(bin_path)

--- a/extensions/nns/src/main.rs
+++ b/extensions/nns/src/main.rs
@@ -1,7 +1,7 @@
 //! Code for the command line `dfx nns`.
 #![warn(clippy::missing_docs_in_private_items)]
 
-use std::{path::PathBuf, str::FromStr};
+use std::path::PathBuf;
 
 use clap::Parser;
 use tokio::runtime::Runtime;
@@ -20,8 +20,8 @@ pub struct NnsOpts {
 
     // global args have to be wrapped with Option for now: https://github.com/clap-rs/clap/issues/1546
     /// Path to cache of DFX which executed this extension.
-    #[arg(long, global = true)]
-    dfx_cache_path: Option<String>,
+    #[arg(long, env = "DFX_CACHE_PATH", global = true)]
+    dfx_cache_path: Option<PathBuf>,
 }
 
 /// Command line options for subcommands of `dfx nns`.
@@ -36,15 +36,12 @@ enum SubCommand {
 /// Executes `dfx nns` and its subcommands.
 pub fn main() -> anyhow::Result<()> {
     let opts = NnsOpts::parse();
-    let dfx_cache_path = PathBuf::from_str(
-        &opts
-            .dfx_cache_path
-            .ok_or_else(|| {
-                "Missing path to dfx cache. Pass it as CLI argument: `--dfx-cache-path=PATH`"
-            })
-            .map_err(|e| anyhow::anyhow!(e))?,
-    )
-    .map_err(|e| anyhow::anyhow!("Malformed path to dfx cache: {e}"))?;
+    let dfx_cache_path = &opts.dfx_cache_path.ok_or_else(|| {
+        anyhow::Error::msg(
+            "Missing path to dfx cache. Pass it as CLI argument: `--dfx-cache-path=PATH`",
+        )
+    })?;
+
     let runtime = Runtime::new().expect("Unable to create a runtime");
     runtime.block_on(async {
         match opts.subcmd {

--- a/extensions/nns/src/main.rs
+++ b/extensions/nns/src/main.rs
@@ -1,6 +1,8 @@
 //! Code for the command line `dfx nns`.
 #![warn(clippy::missing_docs_in_private_items)]
 
+use std::{path::PathBuf, str::FromStr};
+
 use clap::Parser;
 use tokio::runtime::Runtime;
 
@@ -15,6 +17,11 @@ pub struct NnsOpts {
     /// `dfx nns` subcommand arguments.
     #[clap(subcommand)]
     subcmd: SubCommand,
+
+    // global args have to be wrapped with Option for now: https://github.com/clap-rs/clap/issues/1546
+    /// Path to cache of DFX which executed this extension.
+    #[arg(long, global = true)]
+    dfx_cache_path: Option<String>,
 }
 
 /// Command line options for subcommands of `dfx nns`.
@@ -29,11 +36,12 @@ enum SubCommand {
 /// Executes `dfx nns` and its subcommands.
 pub fn main() -> anyhow::Result<()> {
     let opts = NnsOpts::parse();
+    let dfx_cache_path = PathBuf::from_str(&opts.dfx_cache_path.unwrap()).unwrap();
     let runtime = Runtime::new().expect("Unable to create a runtime");
     runtime.block_on(async {
         match opts.subcmd {
-            SubCommand::Import(v) => commands::import::exec(v).await,
-            SubCommand::Install(v) => commands::install::exec(v).await,
+            SubCommand::Import(v) => commands::import::exec(v, &dfx_cache_path).await,
+            SubCommand::Install(v) => commands::install::exec(v, &dfx_cache_path).await,
         }
     })
 }

--- a/extensions/nns/src/main.rs
+++ b/extensions/nns/src/main.rs
@@ -36,7 +36,15 @@ enum SubCommand {
 /// Executes `dfx nns` and its subcommands.
 pub fn main() -> anyhow::Result<()> {
     let opts = NnsOpts::parse();
-    let dfx_cache_path = PathBuf::from_str(&opts.dfx_cache_path.unwrap()).unwrap();
+    let dfx_cache_path = PathBuf::from_str(
+        &opts
+            .dfx_cache_path
+            .ok_or_else(|| {
+                "Missing path to dfx cache. Pass it as CLI argument: `--dfx-cache-path=PATH`"
+            })
+            .map_err(|e| anyhow::anyhow!(e))?,
+    )
+    .map_err(|e| anyhow::anyhow!("Malformed path to dfx cache: {e}"))?;
     let runtime = Runtime::new().expect("Unable to create a runtime");
     runtime.block_on(async {
         match opts.subcmd {

--- a/extensions/sns/src/commands/config/create.rs
+++ b/extensions/sns/src/commands/config/create.rs
@@ -1,25 +1,24 @@
 //! Code for executing `dfx sns config create`
+use std::path::Path;
+
 use crate::create_config::create_config;
 use crate::CONFIG_FILE_NAME;
 use clap::Parser;
-use dfx_core::config::cache::get_bin_cache;
 use dfx_core::config::model::dfinity::Config;
-use dfx_extensions_utils::dfx_version;
 
 /// Create an sns config
 #[derive(Parser)]
 pub struct CreateOpts {}
 
 /// Executes `dfx sns config create`
-pub fn exec(_opts: CreateOpts) -> anyhow::Result<()> {
+pub fn exec(_opts: CreateOpts, dfx_cache_path: &Path) -> anyhow::Result<()> {
     let sns_config_path = if let Some(config) = Config::from_current_dir()? {
         config.get_project_root().join(CONFIG_FILE_NAME)
     } else {
         anyhow::bail!("No config file found. Please run `dfx config create` first.");
     };
-    let cache_path = get_bin_cache(&dfx_version()?)?;
 
-    create_config(cache_path, &sns_config_path)?;
+    create_config(dfx_cache_path, &sns_config_path)?;
     println!(
         "Created SNS configuration at: {}",
         sns_config_path.display()

--- a/extensions/sns/src/commands/config/mod.rs
+++ b/extensions/sns/src/commands/config/mod.rs
@@ -1,4 +1,6 @@
 //! Code for the command line `dfx sns config`.
+use std::path::Path;
+
 use clap::Parser;
 
 mod create;
@@ -27,9 +29,9 @@ enum SubCommand {
 }
 
 /// Executes `dfx sns config` and its subcommands.
-pub fn exec(opts: SnsConfigOpts) -> anyhow::Result<()> {
+pub fn exec(opts: SnsConfigOpts, dfx_cache_path: &Path) -> anyhow::Result<()> {
     match opts.subcmd {
-        SubCommand::Create(v) => create::exec(v),
-        SubCommand::Validate(v) => validate::exec(v),
+        SubCommand::Create(v) => create::exec(v, dfx_cache_path),
+        SubCommand::Validate(v) => validate::exec(v, dfx_cache_path),
     }
 }

--- a/extensions/sns/src/commands/config/validate.rs
+++ b/extensions/sns/src/commands/config/validate.rs
@@ -1,23 +1,21 @@
 //! Code for executing `dfx sns config validate`
+use std::path::Path;
+
 use crate::validate_config::validate_config;
 use crate::CONFIG_FILE_NAME;
 use clap::Parser;
-use dfx_core::config::cache::get_bin_cache;
 use dfx_core::config::model::dfinity::Config;
-use dfx_extensions_utils::dfx_version;
 
 /// Validates an SNS configuration
 #[derive(Parser)]
 pub struct ValidateOpts {}
 
 /// Executes `dfx sns config validate`
-pub fn exec(_opts: ValidateOpts) -> anyhow::Result<()> {
+pub fn exec(_opts: ValidateOpts, dfx_cache_path: &Path) -> anyhow::Result<()> {
     let sns_config_path = if let Some(config) = Config::from_current_dir()? {
         config.get_project_root().join(CONFIG_FILE_NAME)
     } else {
         anyhow::bail!("No config file found. Please run `dfx config create` first.");
     };
-    let cache_path = get_bin_cache(&dfx_version()?)?;
-
-    validate_config(cache_path, &sns_config_path).map(|stdout| println!("{}", stdout))
+    validate_config(dfx_cache_path, &sns_config_path).map(|stdout| println!("{}", stdout))
 }

--- a/extensions/sns/src/commands/deploy.rs
+++ b/extensions/sns/src/commands/deploy.rs
@@ -1,10 +1,10 @@
 //! Code for the command line `dfx sns deploy`.
+use std::path::Path;
+
 use crate::deploy::deploy_sns;
 use crate::CONFIG_FILE_NAME;
 use clap::Parser;
-use dfx_core::config::cache::get_bin_cache;
 use dfx_core::config::model::dfinity::Config;
-use dfx_extensions_utils::dfx_version;
 
 /// Creates an SNS on a network.
 ///
@@ -15,15 +15,14 @@ use dfx_extensions_utils::dfx_version;
 pub struct DeployOpts {}
 
 /// Executes the command line `dfx sns deploy`.
-pub fn exec(_opts: DeployOpts) -> anyhow::Result<()> {
+pub fn exec(_opts: DeployOpts, dfx_cache_path: &Path) -> anyhow::Result<()> {
     println!("Creating SNS canisters.  This typically takes about one minute...");
     let sns_config_path = if let Some(config) = Config::from_current_dir()? {
         config.get_project_root().join(CONFIG_FILE_NAME)
     } else {
         anyhow::bail!("No config file found. Please run `dfx config create` first.");
     };
-    let cache_path = get_bin_cache(&dfx_version()?)?;
 
-    println!("{}", deploy_sns(cache_path, &sns_config_path)?);
+    println!("{}", deploy_sns(dfx_cache_path, &sns_config_path)?);
     Ok(())
 }

--- a/extensions/sns/src/commands/download.rs
+++ b/extensions/sns/src/commands/download.rs
@@ -3,7 +3,7 @@ use dfx_extensions_utils::download_sns_wasms;
 use dfx_extensions_utils::replica_rev;
 
 use clap::Parser;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use tokio::runtime::Runtime;
 
 /// Downloads the SNS canister WASMs
@@ -18,12 +18,12 @@ pub struct SnsDownloadOpts {
 }
 
 /// Executes the command line `dfx sns import`.
-pub fn exec(opts: SnsDownloadOpts) -> anyhow::Result<()> {
+pub fn exec(opts: SnsDownloadOpts, dfx_cache_path: &Path) -> anyhow::Result<()> {
     let runtime = Runtime::new().expect("Unable to create a runtime");
     let ic_commit = if let Some(ic_commit) = opts.ic_commit {
         ic_commit
     } else {
-        replica_rev()?
+        replica_rev(dfx_cache_path)?
     };
     runtime.block_on(download_sns_wasms(&ic_commit, &opts.wasms_dir))?;
     Ok(())

--- a/extensions/sns/src/commands/import.rs
+++ b/extensions/sns/src/commands/import.rs
@@ -1,4 +1,6 @@
 //! Code for the command line `dfx sns import`
+use std::path::Path;
+
 use dfx_core::config::model::dfinity::Config;
 use dfx_extensions_utils::{
     get_network_mappings, import_canister_definitions, new_logger, replica_rev,
@@ -21,7 +23,7 @@ pub struct SnsImportOpts {
 }
 
 /// Executes the command line `dfx sns import`.
-pub fn exec(opts: SnsImportOpts) -> anyhow::Result<()> {
+pub fn exec(opts: SnsImportOpts, dfx_cache_path: &Path) -> anyhow::Result<()> {
     let config = Config::from_current_dir()?;
     if config.is_none() {
         anyhow::bail!("No config file found. Please run `dfx config create` first.");
@@ -35,7 +37,7 @@ pub fn exec(opts: SnsImportOpts) -> anyhow::Result<()> {
     let ic_commit = if let Ok(v) = std::env::var("DFX_IC_COMMIT") {
         v
     } else {
-        replica_rev()?
+        replica_rev(dfx_cache_path)?
     };
     let their_dfx_json_location =
         format!("https://raw.githubusercontent.com/dfinity/ic/{ic_commit}/rs/sns/cli/dfx.json");

--- a/extensions/sns/src/create_config.rs
+++ b/extensions/sns/src/create_config.rs
@@ -1,19 +1,19 @@
 //! Code for creating SNS configurations
 use fn_error_context::context;
 use std::ffi::OsString;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use dfx_extensions_utils::call_bundled;
 
 /// Ceates an SNS configuration template.
 #[context("Failed to create sns config at {}.", path.display())]
-pub fn create_config(cache_path: PathBuf, path: &Path) -> anyhow::Result<()> {
+pub fn create_config(dfx_cache_path: &Path, path: &Path) -> anyhow::Result<()> {
     let args = vec![
         OsString::from("init-config-file"),
         OsString::from("--init-config-file-path"),
         OsString::from(path),
         OsString::from("new"),
     ];
-    call_bundled(cache_path, "sns", &args)?;
+    call_bundled(&dfx_cache_path, "sns", &args)?;
     Ok(())
 }

--- a/extensions/sns/src/deploy.rs
+++ b/extensions/sns/src/deploy.rs
@@ -2,13 +2,13 @@
 use anyhow::bail;
 use fn_error_context::context;
 use std::ffi::OsString;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use dfx_extensions_utils::call_bundled;
 
 /// Creates an SNS.  This requires funds but no proposal.
 #[context("Failed to deploy SNS with config: {}", path.display())]
-pub fn deploy_sns(cache_path: PathBuf, path: &Path) -> anyhow::Result<String> {
+pub fn deploy_sns(dfx_cache_path: &Path, path: &Path) -> anyhow::Result<String> {
     // Note: It MAY be possible to get the did file location using existing sdk methods.
     let did_file = "candid/nns-sns-wasm.did";
     if !Path::new(did_file).exists() {
@@ -30,7 +30,7 @@ pub fn deploy_sns(cache_path: PathBuf, path: &Path) -> anyhow::Result<String> {
         OsString::from("--save-to"),
         OsString::from(canister_ids_file),
     ];
-    call_bundled(cache_path, "sns", &args).map(|stdout| {
+    call_bundled(dfx_cache_path, "sns", &args).map(|stdout| {
         format!(
             "Deployed SNS:\nSNS config: {}\nCanister ID file: {}\n\n{}",
             path.display(),

--- a/extensions/sns/src/main.rs
+++ b/extensions/sns/src/main.rs
@@ -8,6 +8,8 @@ pub mod validate_config;
 /// The default location of an SNS configuration file.
 pub const CONFIG_FILE_NAME: &str = "sns.yml";
 
+use std::{path::PathBuf, str::FromStr};
+
 // #![warn(clippy::missing_docs_in_private_items)]
 use crate::{
     commands::config::SnsConfigOpts, commands::deploy::DeployOpts,
@@ -23,6 +25,11 @@ pub struct SnsOpts {
     /// Arguments and flags for subcommands.
     #[clap(subcommand)]
     subcmd: SubCommand,
+
+    // global args have to be wrapped with Option for now: https://github.com/clap-rs/clap/issues/1546
+    /// Path to cache of DFX which executed this extension.
+    #[arg(long, global = true)]
+    dfx_cache_path: Option<String>,
 }
 
 /// Subcommands of `dfx sns`
@@ -45,11 +52,12 @@ enum SubCommand {
 /// Executes `dfx sns` and its subcommands.
 fn main() -> anyhow::Result<()> {
     let opts = SnsOpts::parse();
+    let dfx_cache_path = PathBuf::from_str(&opts.dfx_cache_path.unwrap()).unwrap();
     match opts.subcmd {
-        SubCommand::Config(v) => commands::config::exec(v),
-        SubCommand::Import(v) => commands::import::exec(v),
-        SubCommand::Deploy(v) => commands::deploy::exec(v),
-        SubCommand::Download(v) => commands::download::exec(v),
+        SubCommand::Config(v) => commands::config::exec(v, &dfx_cache_path),
+        SubCommand::Import(v) => commands::import::exec(v, &dfx_cache_path),
+        SubCommand::Deploy(v) => commands::deploy::exec(v, &dfx_cache_path),
+        SubCommand::Download(v) => commands::download::exec(v, &dfx_cache_path),
     }?;
     Ok(())
 }

--- a/extensions/sns/src/main.rs
+++ b/extensions/sns/src/main.rs
@@ -52,7 +52,15 @@ enum SubCommand {
 /// Executes `dfx sns` and its subcommands.
 fn main() -> anyhow::Result<()> {
     let opts = SnsOpts::parse();
-    let dfx_cache_path = PathBuf::from_str(&opts.dfx_cache_path.unwrap()).unwrap();
+    let dfx_cache_path = PathBuf::from_str(
+        &opts
+            .dfx_cache_path
+            .ok_or_else(|| {
+                "Missing path to dfx cache. Pass it as CLI argument: `--dfx-cache-path=PATH`"
+            })
+            .map_err(|e| anyhow::anyhow!(e))?,
+    )
+    .map_err(|e| anyhow::anyhow!("Malformed path to dfx cache: {e}"))?;
     match opts.subcmd {
         SubCommand::Config(v) => commands::config::exec(v, &dfx_cache_path),
         SubCommand::Import(v) => commands::import::exec(v, &dfx_cache_path),

--- a/extensions/sns/src/validate_config.rs
+++ b/extensions/sns/src/validate_config.rs
@@ -1,19 +1,19 @@
 //! Code for checking SNS config file validity
 use fn_error_context::context;
 use std::ffi::OsString;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use dfx_extensions_utils::call_bundled;
 
 /// Checks whether an SNS configuration file is valid.
 #[context("Failed to validate SNS config at {}.", path.display())]
-pub fn validate_config(cache_path: PathBuf, path: &Path) -> anyhow::Result<String> {
+pub fn validate_config(dfx_cache_path: &Path, path: &Path) -> anyhow::Result<String> {
     let args = vec![
         OsString::from("init-config-file"),
         OsString::from("--init-config-file-path"),
         OsString::from(path),
         OsString::from("validate"),
     ];
-    call_bundled(cache_path, "sns", &args)
+    call_bundled(dfx_cache_path, "sns", &args)
         .map(|_| format!("SNS config file is valid: {}", path.display()))
 }


### PR DESCRIPTION
implementation of https://github.com/dfinity/sdk/pull/3169
> Some dfx extensions depend on binaries from dfx's cache. Previously, extensions depended on the first dfx in $PATH to locate its cache, which is error-prone for projects that declare a custom dfx version in their dfx.json.


