### PR TITLE
fix(nns-extension): accept multiple args

### DIFF
--- a/extensions/nns/src/commands/install.rs
+++ b/extensions/nns/src/commands/install.rs
@@ -32,7 +32,7 @@ use ic_agent::Agent;
 #[clap(about)]
 pub struct InstallOpts {
     /// Initialize ledger canister with these test accounts
-    #[arg(long, action = clap::ArgAction::Append)]
+    #[arg(long, action = clap::ArgAction::Append, num_args = 0..)]
     ledger_accounts: Vec<String>,
 }
 


### PR DESCRIPTION
this fixes the issue where you'd have to write `--ledger-accounts` multiple times

### from
```console
cargo run -p nns install --ledger-accounts fefe --ledger-accounts fefe --dfx-cache-path=$(dfx cache show)
```

### to
```console
cargo run -p nns install --ledger-accounts fefe fefe  --dfx-cache-path=$(dfx cache show)
```