### PR TITLE
fix(release): cargo-release replacement targets `extension.json`

### DIFF
--- a/extensions/nns/Cargo.toml
+++ b/extensions/nns/Cargo.toml
@@ -42,7 +42,7 @@ pre-release-replacements = [
   {file="CHANGELOG.md", search="ReleaseDate", replace="{{date}}"},
   {file="CHANGELOG.md", search="<!-- next-header -->", replace="<!-- next-header -->\n\n## [Unreleased] - ReleaseDate", exactly=1},
   {file="CHANGELOG.md", search="<!-- next-url -->", replace="<!-- next-url -->\n[Unreleased]: https://github.com/dfinity/dfx-extensions/compare/{{tag_name}}...HEAD", exactly=1},
-  {file="extension.toml", search="version = .*", replace="version = \"{{version}}\"", exactly=1},
+  {file="extension.json", search="\"version\": .*", replace="\"version\": \"{{version}}\",", exactly=1},
 ]
 
 [package.metadata.dist]

--- a/extensions/sns/Cargo.toml
+++ b/extensions/sns/Cargo.toml
@@ -30,7 +30,7 @@ pre-release-replacements = [
   {file="CHANGELOG.md", search="ReleaseDate", replace="{{date}}"},
   {file="CHANGELOG.md", search="<!-- next-header -->", replace="<!-- next-header -->\n\n## [Unreleased] - ReleaseDate", exactly=1},
   {file="CHANGELOG.md", search="<!-- next-url -->", replace="<!-- next-url -->\n[Unreleased]: https://github.com/dfinity/dfx-extensions/compare/{{tag_name}}...HEAD", exactly=1},
-  {file="extension.toml", search="version = .*", replace="version = \"{{version}}\"", exactly=1},
+  {file="extension.json", search="\"version\": .*", replace="\"version\": \"{{version}}\",", exactly=1},
 ]
 
 [package.metadata.dist]


### PR DESCRIPTION
instead of recently deleted `extension.toml` (in #26)