### PR TITLE
ci(release): add checksum file

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -153,9 +153,14 @@ jobs:
           FILES=$(cat uploads.txt)
           rm uploads.txt
           for i in $FILES; do
+            TAR_ARCHIVE_FILENAME="${i//.tar.xz/.tar}"
+            TAR_GZ_ARCHIVE_FILENAME="$TAR_ARCHIVE_FILENAME.gz"
+            CHECKSUM_FILENAME="$TAR_GZ_ARCHIVE_FILENAME.sha256"
             xz -d -v $i
-            gzip --best --keep --force --no-name ${i//.tar.xz/.tar}
-            echo ${i//.tar.xz/.tar.gz} >> uploads.txt
+            gzip --best --keep --force --no-name "$TAR_ARCHIVE_FILENAME"
+            shasum -a 256 "$TAR_GZ_ARCHIVE_FILENAME" > "$CHECKSUM_FILENAME"
+            echo "$TAR_GZ_ARCHIVE_FILENAME" >> uploads.txt
+            echo "$CHECKSUM_FILENAME" >> uploads.txt
           done
 
           echo "uploading..."

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3512,7 +3512,7 @@ checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
 
 [[package]]
 name = "sns"
-version = "0.0.0"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",


### PR DESCRIPTION
precursor to https://github.com/dfinity/sdk/pull/2968

Release CI adds a checksum file to Github Release
<img width="1139" alt="image" src="https://github.com/dfinity/dfx-extensions/assets/21069150/ec1f0e48-0514-4813-bc4e-c3b9f41ebe71">

This will allow us to verify checksum for DFINITY dfx extensions. 
Note: the manifest for external dfx extensions already requires specifying the checksum for the extension archive. 

tested on fork repo: https://github.com/smallstepman/dfx-extensions-fork/releases

