### PR TITLE
feat: ic binary dependencies are included in tarball

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,9 @@ target/
 
 ## MSVC Windows builds of rustc generate these, which store debugging information
 *.pdb
+
+## don't include binaries that are downloaded in build.rs scripts
+extensions/sns/sns-cli
+extensions/nns/ic-admin
+extensions/nns/ic-nns-init
+extensions/nns/sns-cli

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -174,9 +174,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.71"
+version = "1.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
+checksum = "3b13c32d80ecc7ab747b80c3784bce54ee8a7a0cc4fbda9bf4cda2cf6fe90854"
 
 [[package]]
 name = "arbitrary"
@@ -247,13 +247,13 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.71"
+version = "0.1.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a564d521dd56509c4c47480d00b80ee55f7e385ae48db5744c67ad50c92d2ebf"
+checksum = "cc6dde6e4ed435a4c1ee4e73592f5ba9da2151af10076cc04858746af9352d09"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.25",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -572,9 +572,9 @@ checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
 
 [[package]]
 name = "candid"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4df671c37a9c6168db0334f2b289dd4e02dea1bbefe1fb22c5d43b12d865aacd"
+checksum = "73f6dd83439943085a6d03503f55c3c9329052a2ad815d24a0c1a0ce6147690e"
 dependencies = [
  "anyhow",
  "arbitrary",
@@ -613,14 +613,17 @@ dependencies = [
  "lazy_static",
  "proc-macro2",
  "quote",
- "syn 2.0.25",
+ "syn 2.0.28",
 ]
 
 [[package]]
 name = "cc"
-version = "1.0.79"
+version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
+checksum = "6c6b2562119bf28c3439f7f02db99faf0aa1a8cdfe5772a2ee155d32227239f0"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "cfg-if"
@@ -639,9 +642,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.3.11"
+version = "4.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1640e5cc7fb47dbb8338fd471b105e7ed6c3cb2aeb00c2e067127ffd3764a05d"
+checksum = "5fd304a20bff958a57f04c4e96a2e7594cc4490a0e809cbd48bb6437edaa452d"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -650,9 +653,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.3.11"
+version = "4.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98c59138d527eeaf9b53f35a77fcc1fad9d883116070c63d5de1c7dc7b00c72b"
+checksum = "01c6a3f08f1fe5662a35cfe393aec09c4df95f60ee93b7556505260f75eee9e1"
 dependencies = [
  "anstream",
  "anstyle",
@@ -662,14 +665,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.3.2"
+version = "4.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8cd2b2a819ad6eec39e8f1d6b53001af1e5469f8c177579cdaeb313115b825f"
+checksum = "54a9bb5758fc5dfe728d1019941681eccaf0cf8a4189b692a0ee2f2ecf90a050"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.25",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -872,6 +875,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "deranged"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8810e7e2cf385b1e9b50d68264908ec367ba642c96d02edfe61c39e88e2a3c01"
+
+[[package]]
 name = "derivative"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1053,9 +1062,9 @@ checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "dyn-clone"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68b0cf012f1230e43cd00ebb729c6bb58707ecfa8ad08b52ef3a4ccd2697fc30"
+checksum = "304e6508efa593091e97a9abbc10f90aa7ca635b6d2784feff3c89d41dd12272"
 
 [[package]]
 name = "ecdsa"
@@ -1071,9 +1080,9 @@ dependencies = [
 
 [[package]]
 name = "ecdsa"
-version = "0.16.7"
+version = "0.16.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0997c976637b606099b9985693efa3581e84e41f5c11ba5255f88711058ad428"
+checksum = "a4b1e0c257a9e9f25f90ff76d7a68360ed497ee519c8e428d1825ef0000799d4"
 dependencies = [
  "der 0.7.7",
  "digest 0.10.7",
@@ -1085,9 +1094,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
+checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 
 [[package]]
 name = "elliptic-curve"
@@ -1125,7 +1134,7 @@ dependencies = [
  "pem-rfc7468 0.7.0",
  "pkcs8 0.10.2",
  "rand_core",
- "sec1 0.7.2",
+ "sec1 0.7.3",
  "subtle",
  "zeroize",
 ]
@@ -1192,9 +1201,9 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
+checksum = "6b30f669a7961ef1631673d2766cc92f52d64f7ef354d4fe0ddfd30ed52f0f4f"
 dependencies = [
  "errno-dragonfly",
  "libc",
@@ -1235,6 +1244,12 @@ checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
 dependencies = [
  "instant",
 ]
+
+[[package]]
+name = "fastrand"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6999dc1837253364c2ebb0704ba97994bd874e8f195d665c50b7548f6ea92764"
 
 [[package]]
 name = "ff"
@@ -1293,7 +1308,7 @@ checksum = "2cd66269887534af4b0c3e3337404591daa8dc8b9b2b3db71f9523beb4bafb41"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.25",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -1386,7 +1401,7 @@ version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49a9d51ce47660b1e808d3c990b4709f2f415d928835a17dfd16991515c46bce"
 dependencies = [
- "fastrand",
+ "fastrand 1.9.0",
  "futures-core",
  "futures-io",
  "memchr",
@@ -1403,7 +1418,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.25",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -1712,7 +1727,7 @@ dependencies = [
  "futures-util",
  "http",
  "hyper",
- "rustls 0.21.5",
+ "rustls 0.21.6",
  "tokio",
  "tokio-rustls 0.24.1",
 ]
@@ -1751,7 +1766,7 @@ dependencies = [
  "reqwest",
  "ring",
  "rustls 0.20.8",
- "sec1 0.7.2",
+ "sec1 0.7.3",
  "serde",
  "serde_bytes",
  "serde_cbor",
@@ -1882,7 +1897,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
  "hermit-abi 0.3.2",
- "rustix 0.38.4",
+ "rustix 0.38.6",
  "windows-sys 0.48.0",
 ]
 
@@ -1906,9 +1921,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b02a5381cc465bd3041d84623d0fa3b66738b52b8e2fc3bab8ad63ab032f4a"
+checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 
 [[package]]
 name = "js-sys"
@@ -1939,7 +1954,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cadb76004ed8e97623117f3df85b17aaa6626ab0b0831e6573f104df16cd1bcc"
 dependencies = [
  "cfg-if",
- "ecdsa 0.16.7",
+ "ecdsa 0.16.8",
  "elliptic-curve 0.13.5",
  "once_cell",
  "sha2 0.10.7",
@@ -2029,9 +2044,9 @@ dependencies = [
 
 [[package]]
 name = "libz-ng-sys"
-version = "1.1.9"
+version = "1.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2468756f34903b582fe7154dc1ffdebd89d0562c4a43b53c621bb0f1b1043ccb"
+checksum = "3dd9f43e75536a46ee0f92b758f6b63846e594e86638c61a9251338a65baea63"
 dependencies = [
  "cmake",
  "libc",
@@ -2045,9 +2060,9 @@ checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.3"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09fc20d2ca12cb9f044c93e3bd6d32d523e6e2ec3db4f7b2939cd99026ecd3f0"
+checksum = "57bcfdad1b858c2db7c38303a6d2ad4dfaf5eb53dfeb0910128b2c26d6158503"
 
 [[package]]
 name = "lock_api"
@@ -2085,7 +2100,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex-syntax 0.6.29",
- "syn 2.0.25",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -2307,9 +2322,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
+checksum = "f30b0abd723be7e2ffca1272140fac1a2f084c77ec3e123c192b66af1ee9e6c2"
 dependencies = [
  "autocfg",
 ]
@@ -2342,7 +2357,7 @@ dependencies = [
  "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
- "syn 2.0.25",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -2398,7 +2413,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.25",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -2409,9 +2424,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-src"
-version = "111.26.0+1.1.1u"
+version = "111.27.0+1.1.1v"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efc62c9f12b22b8f5208c23a7200a442b2e5999f8bdf80233852122b5a4f6f37"
+checksum = "06e8f197c82d7511c5b014030c9b1efeda40d7d5f99d23b4ceed3524a5e63f02"
 dependencies = [
  "cc",
 ]
@@ -2480,9 +2495,9 @@ dependencies = [
 
 [[package]]
 name = "paste"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4b27ab7be369122c218afc2079489cdcb4b517c0a3fc386ff11e1fedfcc2b35"
+checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
 
 [[package]]
 name = "pbkdf2"
@@ -2529,9 +2544,9 @@ checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
 
 [[package]]
 name = "pest"
-version = "2.7.0"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f73935e4d55e2abf7f130186537b19e7a4abc886a0252380b59248af473a3fc9"
+checksum = "1acb4a4365a13f749a93f1a094a7805e5cfa0955373a9de860d962eaa3a5fe5a"
 dependencies = [
  "thiserror",
  "ucd-trie",
@@ -2561,9 +2576,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.7.0"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aef623c9bbfa0eedf5a0efba11a5ee83209c326653ca31ff019bec3a95bfff2b"
+checksum = "666d00490d4ac815001da55838c500eafb0320019bbaa44444137c48b443a853"
 dependencies = [
  "pest",
  "pest_generator",
@@ -2571,22 +2586,22 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.7.0"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3e8cba4ec22bada7fc55ffe51e2deb6a0e0db2d0b7ab0b103acc80d2510c190"
+checksum = "68ca01446f50dbda87c1786af8770d535423fa8a53aec03b8f4e3d7eb10e0929"
 dependencies = [
  "pest",
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.25",
+ "syn 2.0.28",
 ]
 
 [[package]]
 name = "pest_meta"
-version = "2.7.0"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a01f71cb40bd8bb94232df14b946909e14660e33fc05db3e50ae2a82d7ea0ca0"
+checksum = "56af0a30af74d0445c0bf6d9d051c979b516a1a5af790d251daee76005420a48"
 dependencies = [
  "once_cell",
  "pest",
@@ -2750,9 +2765,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.64"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78803b62cbf1f46fde80d7c0e803111524b9877184cfe7c3033659490ac7a7da"
+checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
 dependencies = [
  "unicode-ident",
 ]
@@ -2788,9 +2803,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.29"
+version = "1.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "573015e8ab27661678357f27dc26460738fd2b6c86e46f386fde94cb5d913105"
+checksum = "50f3b39ccfb720540debaa0164757101c08ecb8d326b15358ce76a62c7e85965"
 dependencies = [
  "proc-macro2",
 ]
@@ -2874,9 +2889,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.3.2"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83d3daa6976cffb758ec878f108ba0e062a45b2d6ca3a2cca965338855476caf"
+checksum = "b7b6d6190b7594385f61bd3911cd1be99dfddcfc365a4160cc2ab5bff4aed294"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2929,7 +2944,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls 0.21.5",
+ "rustls 0.21.6",
  "rustls-pemfile",
  "serde",
  "serde_json",
@@ -3023,13 +3038,12 @@ dependencies = [
 
 [[package]]
 name = "rust_decimal"
-version = "1.30.0"
+version = "1.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0446843641c69436765a35a5a77088e28c2e6a12da93e84aa3ab1cd4aa5a042"
+checksum = "4a2ab0025103a60ecaaf3abf24db1db240a4e1c15837090d2c32f625ac98abea"
 dependencies = [
  "arrayvec 0.7.4",
  "borsh",
- "bytecheck",
  "byteorder",
  "bytes",
  "num-traits",
@@ -3067,14 +3081,14 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.4"
+version = "0.38.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a962918ea88d644592894bc6dc55acc6c0956488adcebbfb6e273506b7fd6e5"
+checksum = "1ee020b1716f0a80e2ace9b03441a749e402e86712f15f16fe8a8f75afac732f"
 dependencies = [
  "bitflags 2.3.3",
  "errno",
  "libc",
- "linux-raw-sys 0.4.3",
+ "linux-raw-sys 0.4.5",
  "windows-sys 0.48.0",
 ]
 
@@ -3092,9 +3106,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.5"
+version = "0.21.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79ea77c539259495ce8ca47f53e66ae0330a8819f67e23ac96ca02f50e7b7d36"
+checksum = "1d1feddffcfcc0b33f5c6ce9a29e341e4cd59c3f78e7ee45f4a40c038b1d6cbb"
 dependencies = [
  "log",
  "ring",
@@ -3125,9 +3139,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.101.1"
+version = "0.101.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15f36a6828982f422756984e47912a7a51dcbc2a197aa791158f8ca61cd8204e"
+checksum = "513722fd73ad80a71f72b61009ea1b584bcfa1483ca93949c8f290298837fa59"
 dependencies = [
  "ring",
  "untrusted",
@@ -3135,15 +3149,15 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc31bd9b61a32c31f9650d18add92aa83a49ba979c143eefd27fe7177b05bd5f"
+checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
 
 [[package]]
 name = "ryu"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe232bdf6be8c8de797b22184ee71118d63780ea42ac85b61d1baa6d3b782ae9"
+checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
 
 [[package]]
 name = "schannel"
@@ -3186,9 +3200,9 @@ checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "scopeguard"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "sct"
@@ -3222,9 +3236,9 @@ dependencies = [
 
 [[package]]
 name = "sec1"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0aec48e813d6b90b15f0b8948af3c63483992dee44c03e9930b3eebdabe046e"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
  "base16ct 0.2.0",
  "der 0.7.7",
@@ -3256,9 +3270,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.9.1"
+version = "2.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fc758eb7bffce5b308734e9b0c1468893cae9ff70ebf13e7090be8dcbcc83a8"
+checksum = "05b64fb303737d99b81884b2c63433e9ae28abebe5eb5045dcdd175dc2ecf4de"
 dependencies = [
  "bitflags 1.3.2",
  "core-foundation",
@@ -3269,9 +3283,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.9.0"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f51d0c0d83bec45f16480d0ce0058397a69e48fcdc52d1dc8855fb68acbd31a7"
+checksum = "e932934257d3b408ed8f30db49d85ea163bfe74961f017f405b025af298f0c7a"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -3279,24 +3293,24 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
+checksum = "b0293b4b29daaf487284529cc2f5675b8e57c61f70167ba415a463651fd6a918"
 
 [[package]]
 name = "serde"
-version = "1.0.171"
+version = "1.0.180"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30e27d1e4fd7659406c492fd6cfaf2066ba8773de45ca75e855590f856dc34a9"
+checksum = "0ea67f183f058fe88a4e3ec6e2788e003840893b91bac4559cabedd00863b3ed"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_bytes"
-version = "0.11.11"
+version = "0.11.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a16be4fe5320ade08736447e3198294a5ea9a6d44dde6f35f0a5e06859c427a"
+checksum = "ab33ec92f677585af6d88c65593ae2375adde54efdbf16d597f2cbc7a6d368ff"
 dependencies = [
  "serde",
 ]
@@ -3313,13 +3327,13 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.171"
+version = "1.0.180"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389894603bd18c46fa56231694f8d827779c0951a667087194cf9de94ed24682"
+checksum = "24e744d7782b686ab3b73267ef05697159cc0e5abbed3f47f9933165e5219036"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.25",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -3348,9 +3362,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.102"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5062a995d481b2308b6064e9af76011f2921c35f97b0468811ed9f6cd91dfed"
+checksum = "076066c5f1078eac5b722a31827a8832fe108bed65dfa75e233c89f8206e976c"
 dependencies = [
  "itoa",
  "ryu",
@@ -3359,13 +3373,13 @@ dependencies = [
 
 [[package]]
 name = "serde_repr"
-version = "0.1.14"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d89a8107374290037607734c0b73a85db7ed80cae314b3c5791f192a496e731"
+checksum = "8725e1dfadb3a50f7e5ce0b1a540466f6ed3fe7a0fca2ac2b8b831d31316bd00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.25",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -3642,9 +3656,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.25"
+version = "2.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15e3fc8c0c74267e2df136e5e5fb656a464158aa57624053375eb9c8c6e25ae2"
+checksum = "04361975b3f5e348b2189d8dc55bc942f278b2d482a6a0365de5bdd62d351567"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3665,9 +3679,9 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tar"
-version = "0.4.38"
+version = "0.4.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b55807c0344e1e6c04d7c965f5289c39a8d94ae23ed5c0b57aabac549f871c6"
+checksum = "ec96d2ffad078296368d46ff1cb309be1c23c513b4ab0e22a45de0185275ac96"
 dependencies = [
  "filetime",
  "libc",
@@ -3676,15 +3690,14 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.6.0"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31c0432476357e58790aaa47a8efb0c5138f137343f3b5f23bd36a27e3b0a6d6"
+checksum = "5486094ee78b2e5038a6382ed7645bc084dc2ec433426ca4c3cb61e2007b8998"
 dependencies = [
- "autocfg",
  "cfg-if",
- "fastrand",
+ "fastrand 2.0.0",
  "redox_syscall 0.3.5",
- "rustix 0.37.23",
+ "rustix 0.38.6",
  "windows-sys 0.48.0",
 ]
 
@@ -3710,22 +3723,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.43"
+version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a35fc5b8971143ca348fa6df4f024d4d55264f3468c71ad1c2f365b0a4d58c42"
+checksum = "611040a08a0439f8248d1990b111c95baa9c704c805fa1f62104b39655fd7f90"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.43"
+version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "463fe12d7993d3b327787537ce8dd4dfa058de32fc2b195ef3cde03dc4771e8f"
+checksum = "090198534930841fab3a5d1bb637cde49e339654e606195f8d9c76eeb081dc96"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.25",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -3740,10 +3753,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.23"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59e399c068f43a5d116fedaf73b203fa4f9c519f17e2b34f63221d3792f81446"
+checksum = "b79eabcd964882a646b3584543ccabeae7869e9ac32a46f6f22b7a5bd405308b"
 dependencies = [
+ "deranged",
  "itoa",
  "libc",
  "num_threads",
@@ -3760,9 +3774,9 @@ checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
 
 [[package]]
 name = "time-macros"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96ba15a897f3c86766b757e5ac7221554c6750054d74d5b28844fce5fb36a6c4"
+checksum = "eb71511c991639bb078fd5bf97757e03914361c48100d52878b8e52b46fb92cd"
 dependencies = [
  "time-core",
 ]
@@ -3854,7 +3868,7 @@ version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
- "rustls 0.21.5",
+ "rustls 0.21.6",
  "tokio",
 ]
 
@@ -3889,9 +3903,9 @@ checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
 
 [[package]]
 name = "toml_edit"
-version = "0.19.12"
+version = "0.19.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c500344a19072298cd05a7224b3c0c629348b78692bf48466c5238656e315a78"
+checksum = "f8123f27e969974a3dfba720fdb560be359f57b44302d280ba72e76a74480e8a"
 dependencies = [
  "indexmap 2.0.0",
  "toml_datetime",
@@ -3956,9 +3970,9 @@ checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22049a19f4a68748a168c0fc439f9516686aa045927ff767eca0a85101fb6e73"
+checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
 
 [[package]]
 name = "unicode-normalization"
@@ -4034,9 +4048,9 @@ checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "uuid"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d023da39d1fde5a8a3fe1f3e01ca9632ada0a63e9797de55a879d6e2236277be"
+checksum = "79daa5ed5740825c40b389c5e50312b9c86df53fccd33f281df655642b43869d"
 
 [[package]]
 name = "vcpkg"
@@ -4092,7 +4106,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.25",
+ "syn 2.0.28",
  "wasm-bindgen-shared",
 ]
 
@@ -4126,7 +4140,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.25",
+ "syn 2.0.28",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -4344,9 +4358,9 @@ checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
 name = "winnow"
-version = "0.4.9"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81a2094c43cc94775293eaa0e499fbc30048a6d824ac82c0351a8c0bf9112529"
+checksum = "f46aab759304e4d7b2075a9aecba26228bb073ee8c50db796b2c72c676b5d807"
 dependencies = [
  "memchr",
 ]
@@ -4388,7 +4402,7 @@ dependencies = [
  "byteorder",
  "derivative",
  "enumflags2",
- "fastrand",
+ "fastrand 1.9.0",
  "futures",
  "nb-connect",
  "nix",
@@ -4430,7 +4444,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.25",
+ "syn 2.0.28",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ dfx-extensions-utils.path = "./extensions-utils"
 
 anyhow = "1.0.70"
 clap = { version = "4.2.1", features = ["derive", "env"] }
+flate2 = { version = "1.0.25", default-features = false, features = ["zlib-ng"] }
 fn-error-context = "0.2.1"
 futures-util = "0.3.28"
 ic-agent = "0.25.0"

--- a/extensions-utils/Cargo.toml
+++ b/extensions-utils/Cargo.toml
@@ -9,6 +9,10 @@ publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[build-dependencies]
+flate2.workspace = true
+reqwest.workspace = true
+
 [dependencies]
 dfx-core.workspace = true
 

--- a/extensions-utils/src/dfx.rs
+++ b/extensions-utils/src/dfx.rs
@@ -7,13 +7,17 @@ use std::ffi::OsStr;
 use std::path::Path;
 use std::process::{self, Command};
 
-/// Calls a bundled command line tool.
+/// Calls a binary from dfx cache.
 ///
 /// # Returns
 /// - On success, returns stdout as a string.
 /// - On error, returns an error message including stdout and stderr.
-#[context("Calling {} CLI, or, it returned an error.", command)]
-pub fn call_bundled<S, I>(dfx_cache_path: &Path, command: &str, args: I) -> anyhow::Result<String>
+#[context("Calling {} CLI failed, or, it returned an error.", command)]
+pub fn call_dfx_bundled_binary<S, I>(
+    dfx_cache_path: &Path,
+    command: &str,
+    args: I,
+) -> anyhow::Result<String>
 where
     I: IntoIterator<Item = S>,
     S: AsRef<OsStr>,
@@ -26,6 +30,57 @@ where
     // The sns command line tool should not rely on commands not packaged with dfx.
     // The same applies to other bundled binaries.
     command.env("PATH", binary.parent().unwrap_or_else(|| Path::new(".")));
+    command
+        .stdin(process::Stdio::null())
+        .output()
+        .map_err(anyhow::Error::from)
+        .and_then(|output| {
+            if output.status.success() {
+                Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+            } else {
+                let args: Vec<_> = command
+                    .get_args()
+                    .into_iter()
+                    .map(OsStr::to_string_lossy)
+                    .collect();
+                Err(anyhow!(
+                    "Call failed:\n{:?} {}\nStdout:\n{}\n\nStderr:\n{}",
+                    command.get_program(),
+                    args.join(" "),
+                    String::from_utf8_lossy(&output.stdout),
+                    String::from_utf8_lossy(&output.stderr)
+                ))
+            }
+        })
+}
+
+/// Calls a binary that was delivered with an extension tarball.
+///
+/// # Returns
+/// - On success, returns stdout as a string.
+/// - On error, returns an error message including stdout and stderr.
+#[context("Calling {} CLI failed, or, it returned an error.", binary_name)]
+pub fn call_extension_bundled_binary<S, I>(binary_name: &str, args: I) -> anyhow::Result<String>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<OsStr>,
+{
+    let extension_binary_path =
+        std::env::current_exe().map_err(|e| anyhow::anyhow!("Failed to get current exe: {}", e))?;
+    let extension_dir_path = extension_binary_path
+        .parent()
+        .unwrap_or_else(|| Path::new("."));
+    let binary_to_call = extension_dir_path.join(binary_name);
+
+    let mut command = Command::new(&binary_to_call);
+    command.args(args);
+    // The sns command line tool itself calls dfx; it should call this dfx.
+    // The sns command line tool should not rely on commands not packaged with dfx.
+    // The same applies to other bundled binaries.
+    command.env(
+        "PATH",
+        binary_to_call.parent().unwrap_or_else(|| Path::new(".")),
+    );
     command
         .stdin(process::Stdio::null())
         .output()

--- a/extensions-utils/src/download_dependencies.rs
+++ b/extensions-utils/src/download_dependencies.rs
@@ -1,0 +1,38 @@
+use flate2::read::GzDecoder;
+use std::fs::File;
+use std::path::Path;
+use std::{env, fs, io::copy};
+
+pub fn download_ic_binary(replica_rev: &str, binary_name: &str, renamed_binary_name: &str) {
+    let arch = match std::env::consts::ARCH {
+        "x86_64" => "x86_64",
+        "aarch64" => "x86_64", // let's rely on rosetta2 for now, since sns-cli is not available for arm64
+        _ => panic!("Unsupported architecture"),
+    };
+    let os = match std::env::consts::OS {
+        "macos" => "darwin",
+        "linux" => "linux",
+        // "windows" => "windows", // unsupported till dfx supports windows
+        _ => panic!("Unsupported OS"),
+    };
+
+    let url = format!(
+        "https://download.dfinity.systems/ic/{replica_rev}/openssl-static-binaries/{arch}-{os}/{binary_name}.gz",
+        arch = arch,
+        os = os,
+        binary_name = binary_name,
+    );
+    println!("Downloading {}", url);
+
+    let resp = reqwest::blocking::get(&url).expect("Request failed");
+    let bytes = resp.bytes().expect("Failed to read response");
+
+    let mut d = GzDecoder::new(&*bytes);
+    let mut dest = File::create(binary_name).expect("Failed to create sns file");
+
+    copy(&mut d, &mut dest).expect("Failed to copy content");
+
+    let manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
+    let out_path = Path::new(&manifest_dir).join(renamed_binary_name);
+    fs::rename(binary_name, out_path).expect("Failed to move sns");
+}

--- a/extensions-utils/src/lib.rs
+++ b/extensions-utils/src/lib.rs
@@ -1,12 +1,16 @@
 //! Library for calling bundled command line tools.
 
 mod dfx;
+pub mod download_dependencies;
 mod download_wasms;
 mod error;
 mod logger;
 mod project;
 
-pub use dfx::{call_bundled, dfx_version, replica_rev, webserver_port};
+pub use dfx::{
+    call_dfx_bundled_binary, call_extension_bundled_binary, dfx_version, replica_rev,
+    webserver_port,
+};
 pub use download_wasms::download_ic_repo_wasm;
 pub use download_wasms::nns::download_nns_wasms;
 pub use download_wasms::nns::{

--- a/extensions/nns/Cargo.toml
+++ b/extensions/nns/Cargo.toml
@@ -8,6 +8,10 @@ repository.workspace = true
 # Temp hack until https://github.com/axodotdev/cargo-dist/issues/187 is resovled.
 # Nothing will actually be published (unless `cargo publish` is executed (and it shouldn't)).
 publish = true
+build = "build.rs"
+
+[build-dependencies]
+dfx-extensions-utils.workspace = true
 
 [dependencies]
 dfx-core.workspace = true
@@ -46,5 +50,4 @@ pre-release-replacements = [
 ]
 
 [package.metadata.dist]
-include = ["extension.json"]
-
+include = ["extension.json", "sns-cli", "ic-admin", "ic-nns-init"]

--- a/extensions/nns/build.rs
+++ b/extensions/nns/build.rs
@@ -1,0 +1,18 @@
+const REPLICA_REV: &str = "0062aec2efc16d6e4cadb2cd1052aaabbc9f6e48";
+
+const BINARY_DEPENDENCIES: &[(&str, &str)] = &[
+    // (downloaded binary name, renamed binary name)
+    ("ic-nns-init", "ic-nns-init"),
+    ("ic-admin", "ic-admin"),
+    ("sns", "sns-cli"),
+];
+
+fn main() {
+    for (binary_name, renamed_binary_name) in BINARY_DEPENDENCIES {
+        dfx_extensions_utils::download_dependencies::download_ic_binary(
+            REPLICA_REV,
+            binary_name,
+            renamed_binary_name,
+        );
+    }
+}

--- a/extensions/nns/src/commands/install.rs
+++ b/extensions/nns/src/commands/install.rs
@@ -69,14 +69,11 @@ pub async fn exec(opts: InstallOpts, dfx_cache_path: &Path) -> anyhow::Result<()
 
     fetch_root_key_when_local(&agent, &network_descriptor).await?;
 
-    let ic_nns_init_path = dfx_cache_path.join("ic-nns-init");
-
     install_nns(
         &agent,
         &network_descriptor,
         &networks_config,
         &dfx_cache_path,
-        &ic_nns_init_path,
         &opts.ledger_accounts,
         &logger,
     )

--- a/extensions/sns/Cargo.toml
+++ b/extensions/sns/Cargo.toml
@@ -8,6 +8,10 @@ repository.workspace = true
 # Temp hack until https://github.com/axodotdev/cargo-dist/issues/187 is resovled.
 # Nothing will actually be published (unless `cargo publish` is executed (and it shouldn't)).
 publish = true
+build = "build.rs"
+
+[build-dependencies]
+dfx-extensions-utils.workspace = true
 
 [dependencies]
 dfx-core.workspace = true
@@ -34,5 +38,4 @@ pre-release-replacements = [
 ]
 
 [package.metadata.dist]
-include = ["extension.json"]
-
+include = ["extension.json", "sns-cli"]

--- a/extensions/sns/build.rs
+++ b/extensions/sns/build.rs
@@ -1,0 +1,16 @@
+const REPLICA_REV: &str = "0062aec2efc16d6e4cadb2cd1052aaabbc9f6e48";
+
+const BINARY_DEPENDENCIES: &[(&str, &str)] = &[
+    // (downloaded binary name, renamed binary name)
+    ("sns", "sns-cli"),
+];
+
+fn main() {
+    for (binary_name, renamed_binary_name) in BINARY_DEPENDENCIES {
+        dfx_extensions_utils::download_dependencies::download_ic_binary(
+            REPLICA_REV,
+            binary_name,
+            renamed_binary_name,
+        );
+    }
+}

--- a/extensions/sns/src/commands/config/create.rs
+++ b/extensions/sns/src/commands/config/create.rs
@@ -1,6 +1,4 @@
 //! Code for executing `dfx sns config create`
-use std::path::Path;
-
 use crate::create_config::create_config;
 use crate::CONFIG_FILE_NAME;
 use clap::Parser;
@@ -11,14 +9,14 @@ use dfx_core::config::model::dfinity::Config;
 pub struct CreateOpts {}
 
 /// Executes `dfx sns config create`
-pub fn exec(_opts: CreateOpts, dfx_cache_path: &Path) -> anyhow::Result<()> {
+pub fn exec(_opts: CreateOpts) -> anyhow::Result<()> {
     let sns_config_path = if let Some(config) = Config::from_current_dir()? {
         config.get_project_root().join(CONFIG_FILE_NAME)
     } else {
         anyhow::bail!(crate::errors::DFXJSON_NOT_FOUND);
     };
 
-    create_config(dfx_cache_path, &sns_config_path)?;
+    create_config(&sns_config_path)?;
     println!(
         "Created SNS configuration at: {}",
         sns_config_path.display()

--- a/extensions/sns/src/commands/config/mod.rs
+++ b/extensions/sns/src/commands/config/mod.rs
@@ -1,6 +1,4 @@
 //! Code for the command line `dfx sns config`.
-use std::path::Path;
-
 use clap::Parser;
 
 mod create;
@@ -29,9 +27,9 @@ enum SubCommand {
 }
 
 /// Executes `dfx sns config` and its subcommands.
-pub fn exec(opts: SnsConfigOpts, dfx_cache_path: &Path) -> anyhow::Result<()> {
+pub fn exec(opts: SnsConfigOpts) -> anyhow::Result<()> {
     match opts.subcmd {
-        SubCommand::Create(v) => create::exec(v, dfx_cache_path),
-        SubCommand::Validate(v) => validate::exec(v, dfx_cache_path),
+        SubCommand::Create(v) => create::exec(v),
+        SubCommand::Validate(v) => validate::exec(v),
     }
 }

--- a/extensions/sns/src/commands/config/validate.rs
+++ b/extensions/sns/src/commands/config/validate.rs
@@ -1,6 +1,4 @@
 //! Code for executing `dfx sns config validate`
-use std::path::Path;
-
 use crate::validate_config::validate_config;
 use crate::CONFIG_FILE_NAME;
 use clap::Parser;
@@ -11,11 +9,11 @@ use dfx_core::config::model::dfinity::Config;
 pub struct ValidateOpts {}
 
 /// Executes `dfx sns config validate`
-pub fn exec(_opts: ValidateOpts, dfx_cache_path: &Path) -> anyhow::Result<()> {
+pub fn exec(_opts: ValidateOpts) -> anyhow::Result<()> {
     let sns_config_path = if let Some(config) = Config::from_current_dir()? {
         config.get_project_root().join(CONFIG_FILE_NAME)
     } else {
         anyhow::bail!(crate::errors::DFXJSON_NOT_FOUND);
     };
-    validate_config(dfx_cache_path, &sns_config_path).map(|stdout| println!("{}", stdout))
+    validate_config(&sns_config_path).map(|stdout| println!("{}", stdout))
 }

--- a/extensions/sns/src/commands/deploy.rs
+++ b/extensions/sns/src/commands/deploy.rs
@@ -1,6 +1,4 @@
 //! Code for the command line `dfx sns deploy`.
-use std::path::Path;
-
 use crate::deploy::deploy_sns;
 use crate::CONFIG_FILE_NAME;
 use clap::Parser;
@@ -15,7 +13,7 @@ use dfx_core::config::model::dfinity::Config;
 pub struct DeployOpts {}
 
 /// Executes the command line `dfx sns deploy`.
-pub fn exec(_opts: DeployOpts, dfx_cache_path: &Path) -> anyhow::Result<()> {
+pub fn exec(_opts: DeployOpts) -> anyhow::Result<()> {
     println!("Creating SNS canisters.  This typically takes about one minute...");
     let sns_config_path = if let Some(config) = Config::from_current_dir()? {
         config.get_project_root().join(CONFIG_FILE_NAME)
@@ -23,6 +21,6 @@ pub fn exec(_opts: DeployOpts, dfx_cache_path: &Path) -> anyhow::Result<()> {
         anyhow::bail!(crate::errors::DFXJSON_NOT_FOUND);
     };
 
-    println!("{}", deploy_sns(dfx_cache_path, &sns_config_path)?);
+    println!("{}", deploy_sns(&sns_config_path)?);
     Ok(())
 }

--- a/extensions/sns/src/create_config.rs
+++ b/extensions/sns/src/create_config.rs
@@ -3,17 +3,17 @@ use fn_error_context::context;
 use std::ffi::OsString;
 use std::path::Path;
 
-use dfx_extensions_utils::call_bundled;
+use dfx_extensions_utils::call_extension_bundled_binary;
 
 /// Ceates an SNS configuration template.
 #[context("Failed to create sns config at {}.", path.display())]
-pub fn create_config(dfx_cache_path: &Path, path: &Path) -> anyhow::Result<()> {
+pub fn create_config(path: &Path) -> anyhow::Result<()> {
     let args = vec![
         OsString::from("init-config-file"),
         OsString::from("--init-config-file-path"),
         OsString::from(path),
         OsString::from("new"),
     ];
-    call_bundled(&dfx_cache_path, "sns", &args)?;
+    call_extension_bundled_binary("sns-cli", &args)?;
     Ok(())
 }

--- a/extensions/sns/src/deploy.rs
+++ b/extensions/sns/src/deploy.rs
@@ -4,11 +4,11 @@ use fn_error_context::context;
 use std::ffi::OsString;
 use std::path::Path;
 
-use dfx_extensions_utils::call_bundled;
+use dfx_extensions_utils::call_extension_bundled_binary;
 
 /// Creates an SNS.  This requires funds but no proposal.
 #[context("Failed to deploy SNS with config: {}", path.display())]
-pub fn deploy_sns(dfx_cache_path: &Path, path: &Path) -> anyhow::Result<String> {
+pub fn deploy_sns(path: &Path) -> anyhow::Result<String> {
     // Note: It MAY be possible to get the did file location using existing sdk methods.
     let did_file = "candid/nns-sns-wasm.did";
     if !Path::new(did_file).exists() {
@@ -30,7 +30,7 @@ pub fn deploy_sns(dfx_cache_path: &Path, path: &Path) -> anyhow::Result<String> 
         OsString::from("--save-to"),
         OsString::from(canister_ids_file),
     ];
-    call_bundled(dfx_cache_path, "sns", &args).map(|stdout| {
+    call_extension_bundled_binary("sns-cli", &args).map(|stdout| {
         format!(
             "Deployed SNS:\nSNS config: {}\nCanister ID file: {}\n\n{}",
             path.display(),

--- a/extensions/sns/src/main.rs
+++ b/extensions/sns/src/main.rs
@@ -60,9 +60,9 @@ fn main() -> anyhow::Result<()> {
     })?;
 
     match opts.subcmd {
-        SubCommand::Config(v) => commands::config::exec(v, &dfx_cache_path),
+        SubCommand::Config(v) => commands::config::exec(v),
         SubCommand::Import(v) => commands::import::exec(v, &dfx_cache_path),
-        SubCommand::Deploy(v) => commands::deploy::exec(v, &dfx_cache_path),
+        SubCommand::Deploy(v) => commands::deploy::exec(v),
         SubCommand::Download(v) => commands::download::exec(v, &dfx_cache_path),
     }?;
     Ok(())

--- a/extensions/sns/src/validate_config.rs
+++ b/extensions/sns/src/validate_config.rs
@@ -3,17 +3,19 @@ use fn_error_context::context;
 use std::ffi::OsString;
 use std::path::Path;
 
-use dfx_extensions_utils::call_bundled;
+use dfx_extensions_utils::call_extension_bundled_binary;
 
 /// Checks whether an SNS configuration file is valid.
 #[context("Failed to validate SNS config at {}.", path.display())]
-pub fn validate_config(dfx_cache_path: &Path, path: &Path) -> anyhow::Result<String> {
+pub fn validate_config(path: &Path) -> anyhow::Result<String> {
     let args = vec![
         OsString::from("init-config-file"),
         OsString::from("--init-config-file-path"),
         OsString::from(path),
         OsString::from("validate"),
     ];
-    call_bundled(dfx_cache_path, "sns", &args)
+    // current binary
+
+    call_extension_bundled_binary("sns-cli", &args)
         .map(|_| format!("SNS config file is valid: {}", path.display()))
 }


### PR DESCRIPTION
instead of relying on IC binaries that are stored in dfx's cache, we're now packaging the dependencies inside the nns and sns extension tarballs. This allows teams responsible for these extension, to bump the version of these dependencies without the need to wait until they'll be bumped for dfx.

note: e2e tests are *not* covering this change, because they're relying on `dfx extension install` mechanism, which grabs the tarball from github releases. We should find ways to address this in a separate PR