### PR TITLE
test(e2e): test tip of the branch

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -27,6 +27,8 @@ jobs:
         if: contains(matrix.os, 'macos-12') == false
       - name: Install sponge and timeout 
         run: brew install coreutils sponge
+      - name: Install cargo-dist
+        run: cargo install cargo-dist
       - name: Install IC SDK (dfx)
         run: sh -ci "$(curl -sSL https://internetcomputer.org/install.sh)"
       - name: run test

--- a/e2e/utils.sh
+++ b/e2e/utils.sh
@@ -1,7 +1,6 @@
 set -e
 
-GIT_ROOT_DIR="$(git rev-parse --show-toplevel)"
-
+export CARGO_HOME="$HOME"
 load "$GIT_ROOT_DIR"/e2e/bats-support/load
 load "$GIT_ROOT_DIR"/e2e/bats-assert/load
 

--- a/e2e/utils.sh
+++ b/e2e/utils.sh
@@ -25,7 +25,7 @@ install_shared_asset() {
 dfx_extension_install_manually() (
     cd "$GIT_ROOT_DIR"
     local extension_name="$1"
-    package_version=$(HOME="$CARGO_HOME" cargo metadata --format-version=1 | jq -r '.workspace_members[]' | rg "$extension_name" | cut -d" " -f2)
+    package_version=$(HOME="$CARGO_HOME" cargo metadata --format-version=1 | jq -r '.workspace_members[]' | grep "$extension_name" | cut -d" " -f2)
     HOME="$CARGO_HOME" cargo dist build --tag="$extension_name-v$package_version" # cargo-dist needs git tag only metadata-related stuff; it won't do git checkout, it will build from HEAD
     extensions_dir="$(dfx cache show)/extensions"
     arch_platform="$(get_arch_and_platform)"

--- a/e2e/utils.sh
+++ b/e2e/utils.sh
@@ -1,6 +1,6 @@
 set -e
 
-GIT_ROOT_DIR=$(git rev-parse --show-toplevel)
+GIT_ROOT_DIR="$(git rev-parse --show-toplevel)"
 
 load "$GIT_ROOT_DIR"/e2e/bats-support/load
 load "$GIT_ROOT_DIR"/e2e/bats-assert/load

--- a/extensions-utils/src/project/import.rs
+++ b/extensions-utils/src/project/import.rs
@@ -239,16 +239,8 @@ impl Loader {
 
     fn client(&mut self) -> Result<&Client, ProjectError> {
         if self.client.is_none() {
-            let tls_config = rustls::ClientConfig::builder()
-                .with_safe_defaults()
-                .with_webpki_roots()
-                .with_no_client_auth();
-
-            // Advertise support for HTTP/2
-            //tls_config.alpn_protocols = vec![b"h2".to_vec(), b"http/1.1".to_vec()];
-
             let client = reqwest::Client::builder()
-                .use_preconfigured_tls(tls_config)
+                .use_rustls_tls()
                 .build()
                 .map_err(ProjectError::CouldNotCreateHttpClient)?;
             self.client = Some(client);

--- a/extensions-utils/src/project/import.rs
+++ b/extensions-utils/src/project/import.rs
@@ -239,8 +239,16 @@ impl Loader {
 
     fn client(&mut self) -> Result<&Client, ProjectError> {
         if self.client.is_none() {
+            let tls_config = rustls::ClientConfig::builder()
+                .with_safe_defaults()
+                .with_webpki_roots()
+                .with_no_client_auth();
+
+            // Advertise support for HTTP/2
+            //tls_config.alpn_protocols = vec![b"h2".to_vec(), b"http/1.1".to_vec()];
+
             let client = reqwest::Client::builder()
-                .use_rustls_tls()
+                .use_preconfigured_tls(tls_config)
                 .build()
                 .map_err(ProjectError::CouldNotCreateHttpClient)?;
             self.client = Some(client);

--- a/extensions/nns/e2e/tests/nns.bash
+++ b/extensions/nns/e2e/tests/nns.bash
@@ -1,6 +1,7 @@
 #!/usr/bin/env bats
 
-GIT_ROOT_DIR=$(git rev-parse --show-toplevel)
+export GIT_ROOT_DIR=$(git rev-parse --show-toplevel)
+export CARGO_HOME="$HOME"
 
 load "$GIT_ROOT_DIR"/e2e/utils.sh
 
@@ -9,7 +10,7 @@ assets="$(dirname "$BATS_TEST_FILENAME")"/../assets
 setup() {
     standard_setup
 
-    dfx extension install nns
+    dfx_extension_install_manually nns
 
     dfx_new
 }

--- a/extensions/nns/e2e/tests/nns.bash
+++ b/extensions/nns/e2e/tests/nns.bash
@@ -1,6 +1,6 @@
 #!/usr/bin/env bats
 
-export GIT_ROOT_DIR=$(git rev-parse --show-toplevel)
+export GIT_ROOT_DIR="$(git rev-parse --show-toplevel)"
 export CARGO_HOME="$HOME"
 
 load "$GIT_ROOT_DIR"/e2e/utils.sh

--- a/extensions/nns/e2e/tests/nns.bash
+++ b/extensions/nns/e2e/tests/nns.bash
@@ -1,8 +1,6 @@
 #!/usr/bin/env bats
 
 export GIT_ROOT_DIR="$(git rev-parse --show-toplevel)"
-export CARGO_HOME="$HOME"
-
 load "$GIT_ROOT_DIR"/e2e/utils.sh
 
 assets="$(dirname "$BATS_TEST_FILENAME")"/../assets

--- a/extensions/sns/e2e/tests/sns.bash
+++ b/extensions/sns/e2e/tests/sns.bash
@@ -67,7 +67,7 @@ SNS_CONFIG_FILE_NAME="sns.yml"
     rm -f sns.yml # Is not expected to be present anyway
     run dfx sns deploy
     assert_failure
-    assert_output --regexp "Error encountered when generating the SnsInitPayload.* Unable to read .*sns.yml.* No such file or directory"
+    assert_output --regexp "Error encountered when generating the SnsInitPayload.* Couldn't open initial parameters file .*sns.yml.* No such file or directory"
 }
 
 @test "sns deploy succeeds" {

--- a/extensions/sns/e2e/tests/sns.bash
+++ b/extensions/sns/e2e/tests/sns.bash
@@ -1,7 +1,6 @@
 #!/usr/bin/env bats
 
 export GIT_ROOT_DIR="$(git rev-parse --show-toplevel)"
-export CARGO_HOME="$HOME"
 
 load "$GIT_ROOT_DIR"/e2e/utils.sh
 
@@ -67,7 +66,7 @@ SNS_CONFIG_FILE_NAME="sns.yml"
     rm -f sns.yml # Is not expected to be present anyway
     run dfx sns deploy
     assert_failure
-    assert_output --regexp "Error encountered when generating the SnsInitPayload.* Couldn't open initial parameters file .*sns.yml.* No such file or directory"
+    assert_output --partial "Error encountered when generating the SnsInitPayload: Couldn't open initial parameters file"
 }
 
 @test "sns deploy succeeds" {

--- a/extensions/sns/e2e/tests/sns.bash
+++ b/extensions/sns/e2e/tests/sns.bash
@@ -1,13 +1,14 @@
 #!/usr/bin/env bats
 
-GIT_ROOT_DIR=$(git rev-parse --show-toplevel)
+export GIT_ROOT_DIR="$(git rev-parse --show-toplevel)"
+export CARGO_HOME="$HOME"
 
 load "$GIT_ROOT_DIR"/e2e/utils.sh
 
 setup() {
     standard_setup
 
-    dfx extension install sns
+    dfx_extension_install_manually sns
 }
 
 teardown() {
@@ -60,21 +61,21 @@ SNS_CONFIG_FILE_NAME="sns.yml"
 }
 
 @test "sns deploy fails without config file" {
+    dfx_extension_install_manually nns
     dfx_new
-    dfx extension install nns
     dfx nns import
     rm -f sns.yml # Is not expected to be present anyway
     run dfx sns deploy
     assert_failure
-    assert_output --partial "Error encountered when generating the SnsInitPayload: Couldn't open initial parameters file"
+    assert_output --regexp "Error encountered when generating the SnsInitPayload.* Unable to read .*sns.yml.* No such file or directory"
 }
 
 @test "sns deploy succeeds" {
+    dfx_extension_install_manually nns
     dfx_new
     install_shared_asset subnet_type/shared_network_settings/system
     dfx start --clean --background --host 127.0.0.1:8080
     sleep 1
-    dfx extension install nns
     dfx nns install
     dfx nns import
     dfx sns import


### PR DESCRIPTION
This PR changes the way we install extensions in e2e tests. This will allow us to test the latest changes in the codebase and catch any issues early on.

Instead of running tests against the extension installed from the latest release (by installing tarball from GitHub Releases via `dfx extension install`), we will run tests against extensions built from the source code of the tip of the branch. 

We're building the extension from the source code using cargo-dist (the same thing that we're using in release CI) and installing it manually (without using `dfx extensions install ...`, and instead moving the directory with extension to `$(dfx cache show)/extension`; note: perhaps in the future, it will be a good idea to be able to install the extension directly from archive e.g., `dfx extension install --from-archive <URL|PATH>`, this will let us get rid of `dfx_extension_install_manually()` in `e2e/utils.sh`).