### PR TITLE
Update nns.rs - use latest II and NNS Dapp

### DIFF
--- a/extensions-utils/src/dependencies/download_wasms/nns.rs
+++ b/extensions-utils/src/dependencies/download_wasms/nns.rs
@@ -143,14 +143,14 @@ pub const INTERNET_IDENTITY: StandardCanister = StandardCanister {
     canister_name: "internet_identity",
     canister_id: "qhbym-qaaaa-aaaaa-aaafq-cai",
     wasm_name: "internet_identity_dev.wasm",
-    wasm_url: "https://github.com/dfinity/internet-identity/releases/download/release-2022-07-11/internet_identity_dev.wasm"
+    wasm_url: "https://github.com/dfinity/internet-identity/releases/latest/download/internet_identity_dev.wasm.gz"
 };
 /// Frontend dapp for voting and managing neurons.
 pub const NNS_DAPP: StandardCanister = StandardCanister {
     canister_name: "nns-dapp",
     canister_id: "qsgjb-riaaa-aaaaa-aaaga-cai",
     wasm_name: "nns-dapp_local.wasm",
-    wasm_url: "https://github.com/dfinity/nns-dapp/releases/download/tip/nns-dapp_t2.wasm",
+    wasm_url: "https://github.com/dfinity/nns-dapp/releases/latest/download/nns-dapp.wasm.gz",
 };
 /// Backend canisters deployed by `ic nns init`.
 pub const NNS_CORE: &[&IcNnsInitCanister; 11] = &[


### PR DESCRIPTION
As requested by Matthew Grogan, updates II and NNS Dapp for dfx extensions. This will automatically pull the wasm from the release tagged as latest