### PR TITLE
fix: uprgade arg with cycles ledger id gets ignored

### DIFF
--- a/extensions/nns/e2e/tests/nns.bash
+++ b/extensions/nns/e2e/tests/nns.bash
@@ -155,6 +155,7 @@ assert_nns_canister_id_matches() {
     assert_output "$SECP256K1_ACCOUNT_ID"
 
     run dfx --identity ident-1 ledger transfer 4b37224c5ed36e8a28ae39af482f5f858104f0a2285d100e67cf029ff07d948e --amount 10 --memo 1414416717
+    assert_success
     run dfx --identity ident-1 canister call rkp4c-7iaaa-aaaaa-aaaca-cai notify_mint_cycles '(record { block_index = 5; })'
     # If cycles ledger is configured correctly, then notify_mint_cycles will try to call the cycles ledger.
     # If it is not configured correctly, then this will complain about the cycles ledger canister id not being configured.

--- a/extensions/nns/e2e/tests/nns.bash
+++ b/extensions/nns/e2e/tests/nns.bash
@@ -154,6 +154,12 @@ assert_nns_canister_id_matches() {
     assert_success
     assert_output "$SECP256K1_ACCOUNT_ID"
 
+    run dfx --identity ident-1 ledger transfer 4b37224c5ed36e8a28ae39af482f5f858104f0a2285d100e67cf029ff07d948e --amount 10 --memo 1414416717
+    run dfx --identity ident-1 canister call rkp4c-7iaaa-aaaaa-aaaca-cai notify_mint_cycles '(record { block_index = 5; })'
+    # If cycles ledger is configured correctly, then notify_mint_cycles will try to call the cycles ledger.
+    # If it is not configured correctly, then this will complain about the cycles ledger canister id not being configured.
+    assert_output --partial "Canister um5iw-rqaaa-aaaaq-qaaba-cai not found"
+
     echo Stopping dfx...
     dfx stop
 }

--- a/extensions/nns/src/install_nns.rs
+++ b/extensions/nns/src/install_nns.rs
@@ -501,16 +501,13 @@ pub fn set_cycles_ledger_canister_id_in_cmc(
     let cmc_wasm_path = wasm_path.join(NNS_CYCLES_MINTING.wasm_name);
     let cmc_wasm_bytes = dfx_core::fs::read(&cmc_wasm_path)?;
     let wasm_hash = Sha256::digest(cmc_wasm_bytes);
+    let upgrade_arg = format!(
+        "(opt record {{ cycles_ledger_canister_id = opt principal \"{}\" }})",
+        CYCLES_LEDGER.canister_id
+    );
     let mut upgrade_arg_file = tempfile::NamedTempFile::new()?;
     upgrade_arg_file
-        .write_all(
-            &Encode!(&(Some(CyclesCanisterInitPayload {
-                cycles_ledger_canister_id: Some(
-                    Principal::from_text(CYCLES_LEDGER.canister_id).unwrap()
-                ),
-            }),))
-            .unwrap(),
-        )
+        .write_all(upgrade_arg.as_bytes())
         .context("Failed to write to tempfile.")?;
 
     let cmc_wasm_path_str = cmc_wasm_path.to_string_lossy();


### PR DESCRIPTION
#72's upgrade arg gets ignored by the CMC instead of throwing an error thanks to Candid opt rules. 