### PR TITLE
Update SNS and NNS extensions' replica rev

### DIFF
--- a/extensions/nns/CHANGELOG.md
+++ b/extensions/nns/CHANGELOG.md
@@ -1,6 +1,7 @@
 <!-- next-header -->
 
 ## [Unreleased] - ReleaseDate
+- Same functionality as version `0.3.1`.
 
 ## [0.3.1] - 2024-02-09
 - `dfx nns install` now configures the cycles minting canister such that it plays nicely with the cycles ledger (which has to be installed separately).

--- a/extensions/nns/CHANGELOG.md
+++ b/extensions/nns/CHANGELOG.md
@@ -1,7 +1,7 @@
 <!-- next-header -->
 
 ## [Unreleased] - ReleaseDate
-- Same functionality as version `0.3.1`.
+- Updated replica to 8e01c4db9a6676fdd2dd433ef29a44bb3ba1914b.
 
 ## [0.3.1] - 2024-02-09
 - `dfx nns install` now configures the cycles minting canister such that it plays nicely with the cycles ledger (which has to be installed separately).

--- a/extensions/nns/build.rs
+++ b/extensions/nns/build.rs
@@ -1,7 +1,7 @@
 use std::env;
 use std::path::PathBuf;
 
-const REPLICA_REV: &str = "044cfd5147fc97d7e5a214966941b6580c325d72";
+const REPLICA_REV: &str = "8e01c4db9a6676fdd2dd433ef29a44bb3ba1914b";
 
 const BINARY_DEPENDENCIES: &[(&str, &str)] = &[
     // (downloaded binary name, renamed binary name)

--- a/extensions/sns/CHANGELOG.md
+++ b/extensions/sns/CHANGELOG.md
@@ -1,6 +1,7 @@
 <!-- next-header -->
 
 ## [Unreleased] - ReleaseDate
+- Fixes a bug that prevented SNS testflight from working in some cases.
 
 ## [0.3.1] - 2024-02-09
 - Same functionality as version `0.3.0`.

--- a/extensions/sns/CHANGELOG.md
+++ b/extensions/sns/CHANGELOG.md
@@ -1,7 +1,8 @@
 <!-- next-header -->
 
 ## [Unreleased] - ReleaseDate
-- Fixes a bug that prevented SNS testflight from working in some cases.
+- Updated replica to 8e01c4db9a6676fdd2dd433ef29a44bb3ba1914b
+  - Fixes a bug that prevented SNS testflight from working in some cases.
 
 ## [0.3.1] - 2024-02-09
 - Same functionality as version `0.3.0`.

--- a/extensions/sns/build.rs
+++ b/extensions/sns/build.rs
@@ -1,7 +1,7 @@
 use std::env;
 use std::path::PathBuf;
 
-const REPLICA_REV: &str = "044cfd5147fc97d7e5a214966941b6580c325d72";
+const REPLICA_REV: &str = "8e01c4db9a6676fdd2dd433ef29a44bb3ba1914b";
 
 const BINARY_DEPENDENCIES: &[(&str, &str)] = &[
     // (downloaded binary name, renamed binary name)


### PR DESCRIPTION
This is required as newer versions contain a fix for an issue with SNS Testflight