### PR TITLE
fix: for sns propose unable to work with a password-protected identity

### DIFF
--- a/extensions-utils/src/dependencies/mod.rs
+++ b/extensions-utils/src/dependencies/mod.rs
@@ -26,7 +26,7 @@ pub fn execute_command(
     } else {
         command.env("PATH", dfx_cache_path);
     }
-    command.stdin(process::Stdio::null());
+    command.stdin(process::Stdio::inherit());
     command.stdout(process::Stdio::inherit());
     command.stderr(process::Stdio::inherit());
 


### PR DESCRIPTION
This makes it so `dfx sns propose` can work with a password-protected identity.  It will require an update to the sns-cli.

Fixes the dfx-extensions side of https://dfinity.atlassian.net/browse/SDK-1475

How I tested this:

From this repo and branch, build and install the sns extension:
```
$ dfx extension install sns --version 0.3.1
$ chmod +w $(dfx cache show)/extensions/sns/sns
$ cargo build
$ cp target/debug/sns $(dfx cache show)/extensions/sns/sns
```

In the IC repo, apply this patch:
```
diff --git a/rs/sns/cli/src/lib.rs b/rs/sns/cli/src/lib.rs
index 3a7eeefc5..769cd8e69 100644
--- a/rs/sns/cli/src/lib.rs
+++ b/rs/sns/cli/src/lib.rs
@@ -625,7 +625,9 @@ impl<'a> RunCommandError<'a> {
 fn run_command<'a>(command: &'a [&'a str]) -> Result<(String, String), RunCommandError<'a>> {
     let output = std::process::Command::new(command[0])
         .args(&command[1..command.len()])
-        .output()
+        .spawn()
+        .map_err(|error| RunCommandError::UnableToRunCommand { command, error })?
+        .wait_with_output()
         .map_err(|error| RunCommandError::UnableToRunCommand { command, error })?;
 
     let std::process::Output {
```

Build and install sns-cli:
```
$ bazel build //rs/sns/cli:sns
$ cp bazel-bin/rs/sns/cli/sns $(dfx cache show)/extensions/sns/sns-cli
```

Then 
```
$ dfx identity new enc --storage-mode password-protected
$ dfx identity use enc
$ dfx sns propose --neuron-id=15949719352790841058 ./extensions/sns/e2e/assets/sns/valid/sns_v2.yml
```

