### PR TITLE
fix: fail on any error in command pipeline

### DIFF
--- a/.github/workflows/build-extension-manually.sh
+++ b/.github/workflows/build-extension-manually.sh
@@ -1,10 +1,11 @@
 #!/usr/bin/env bash
 
-set -e
+set -e -o pipefail
 
 build_manually() (
   local extension_name="$1"
   package_version=$(cargo metadata --format-version=1 | jq -r '.workspace_members[]' | grep "$extension_name" | cut -d" " -f2)
+  echo "package version for $extension_name: $package_version"
   cargo dist build --tag="$extension_name-v$package_version" # cargo-dist needs git tag only metadata-related stuff; it won't do git checkout, it will build from HEAD
   extension_dir="$PREBUILT_EXTENSIONS_DIR/$extension_name"
   arch_platform="$(get_arch_and_platform)"


### PR DESCRIPTION
Exit earlier if the `cargo metadata` call fails, to avoid followup error messages that are not the problem.

Before
```
error: failed to select a version for `candid`.
    ... required by package `ic-sns-cli v0.9.0 (https://github.com/dfinity/ic?rev=f6a556a24ad934bb33eec0debe3710ce2dbce3ae#f6a556a2)`
    ... which satisfies git dependency `ic-sns-cli` of package `sns v0.3.1 (/Users/ericswanson/ext/anchpop/dfx-extensions/extensions/sns)`
versions that meet the requirements `^0.10.6` are: 0.10.6

all possible versions conflict with previously selected packages.

  previously selected package `candid v0.10.3`
    ... which satisfies dependency `candid = "^0.10.2"` (locked to 0.10.3) of package `nns v0.3.1 (/Users/ericswanson/ext/anchpop/dfx-extensions/extensions/nns)`

failed to select a version for `candid` which could resolve this conflict
  × Couldn't parse the version from the provided announcement tag (nns-v)
  ╰─▶ empty string, expected a semver version
```


After
```
error: failed to select a version for `candid`.
    ... required by package `ic-sns-cli v0.9.0 (https://github.com/dfinity/ic?rev=f6a556a24ad934bb33eec0debe3710ce2dbce3ae#f6a556a2)`
    ... which satisfies git dependency `ic-sns-cli` of package `sns v0.3.1 (/Users/ericswanson/ext/anchpop/dfx-extensions/extensions/sns)`
versions that meet the requirements `^0.10.6` are: 0.10.6

all possible versions conflict with previously selected packages.

  previously selected package `candid v0.10.3`
    ... which satisfies dependency `candid = "^0.10.2"` (locked to 0.10.3) of package `nns v0.3.1 (/Users/ericswanson/ext/anchpop/dfx-extensions/extensions/nns)`

failed to select a version for `candid` which could resolve this conflict
```