### PR TITLE
Remove sns-cli embedded binary dependency from NNS 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,16 +70,16 @@ version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
 dependencies = [
- "getrandom 0.2.12",
+ "getrandom",
  "once_cell",
  "version_check",
 ]
 
 [[package]]
 name = "ahash"
-version = "0.8.9"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d713b3834d76b85304d4d525563c1276e2e30dc97cc67bfb4585a4a29fc2c89f"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -89,9 +89,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
 dependencies = [
  "memchr",
 ]
@@ -119,9 +119,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.12"
+version = "0.6.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96b09b5178381e0874812a9b157f7fe84982617e48f71f4e3235482775e5b540"
+checksum = "d96bd03f33fe50a863e394ee9718a706f988b9079b20c3784fb726e7678b62fb"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -167,9 +167,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.80"
+version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ad32ce52e4161730f7098c077cd2ed6229b5804ccf99e5366be1ab72a98b4e1"
+checksum = "0952808a6c2afd1aa8947271f3a60f1a6763c7b912d210184c5149b5cf147247"
 
 [[package]]
 name = "argon2"
@@ -270,13 +270,13 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.77"
+version = "0.1.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c980ee35e870bd1a4d2c8294d4c04d0499e67bca1e4b5cefcc693c2fa00caea9"
+checksum = "a507401cad91ec6a857ed5513a2073c82a9b9048762b885bb98655b306964681"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -292,9 +292,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+checksum = "f1fdabc7756949593fe60f30ec81974b613357de856987752631dea1e3394c80"
 
 [[package]]
 name = "backoff"
@@ -303,7 +303,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
 dependencies = [
  "futures-core",
- "getrandom 0.2.12",
+ "getrandom",
  "instant",
  "pin-project-lite",
  "rand",
@@ -312,9 +312,9 @@ dependencies = [
 
 [[package]]
 name = "backtrace"
-version = "0.3.69"
+version = "0.3.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2089b7e3f35b9dd2d0ed921ead4f6d318c27680d4a5bd167b3ee120edb105837"
+checksum = "26b05800d2e817c8b3b4b54abd461726265fa9789ae34330622f2db9ee696f9d"
 dependencies = [
  "addr2line",
  "cc",
@@ -404,7 +404,7 @@ dependencies = [
  "k256 0.11.6",
  "once_cell",
  "pbkdf2",
- "rand_core 0.6.4",
+ "rand_core",
  "ripemd",
  "sha2 0.10.8",
  "subtle",
@@ -419,9 +419,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.4.2"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
+checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
 
 [[package]]
 name = "bitvec"
@@ -488,15 +488,15 @@ dependencies = [
  "ff 0.12.1",
  "group 0.12.1",
  "pairing",
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
 ]
 
 [[package]]
 name = "borsh"
-version = "1.3.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f58b559fd6448c6e2fd0adb5720cd98a2506594cafa4737ff98c396f3e82f667"
+checksum = "0901fc8eb0aca4c83be0106d6f2db17d86a08dfc2c25f0e84464bf381158add6"
 dependencies = [
  "borsh-derive",
  "cfg_aliases",
@@ -504,15 +504,15 @@ dependencies = [
 
 [[package]]
 name = "borsh-derive"
-version = "1.3.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aadb5b6ccbd078890f6d7003694e33816e6b784358f18e15e7e6d9f065a57cd"
+checksum = "51670c3aa053938b0ee3bd67c3817e471e626151131b934038e83c5bf8de48f5"
 dependencies = [
  "once_cell",
  "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.55",
  "syn_derive",
 ]
 
@@ -586,15 +586,15 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.15.2"
+version = "3.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3b1be7772ee4501dba05acbe66bb1e8760f6a6c474a36035631638e4415f130"
+checksum = "7ff69b9dd49fd426c69a0db9fc04dd934cdb6645ff000864d98f7e2af8830eaa"
 
 [[package]]
 name = "by_address"
-version = "1.1.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf8dba2868114ed769a1f2590fc9ae5eb331175b44313b6c9b922f8f7ca813d0"
+checksum = "64fa3c856b712db6612c019f14756e64e4bcea13337a6b33b696333a9eaa2d06"
 
 [[package]]
 name = "byte-unit"
@@ -636,9 +636,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.5.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
+checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
 
 [[package]]
 name = "cached"
@@ -658,7 +658,7 @@ version = "0.46.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7c8c50262271cdf5abc979a5f76515c234e764fa025d1ba4862c0f0bcda0e95"
 dependencies = [
- "ahash 0.8.9",
+ "ahash 0.8.11",
  "hashbrown 0.14.3",
  "instant",
  "once_cell",
@@ -676,9 +676,9 @@ dependencies = [
 
 [[package]]
 name = "candid"
-version = "0.10.3"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "182543fbc03b4ad0bfc384e6b68346e0b0aad0b11d075b71b4fcaa5d07f8862c"
+checksum = "965e86b1bd1c0c26df70cf0c92ae16c56204ab402eb915c26a541cf949d841cf"
 dependencies = [
  "anyhow",
  "binread",
@@ -699,21 +699,21 @@ dependencies = [
 
 [[package]]
 name = "candid_derive"
-version = "0.6.5"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "970c220da8aa2fa6f7ef5dbbf3ea5b620a59eb3ac107cfb95ae8c6eebdfb7a08"
+checksum = "3de398570c386726e7a59d9887b68763c481477f9a043fb998a2e09d428df1a9"
 dependencies = [
  "lazy_static",
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.55",
 ]
 
 [[package]]
 name = "cargo-platform"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "694c8807f2ae16faecc43dc17d74b3eb042482789fd0eb64b39a2e04e087053f"
+checksum = "24b1f0365a6c6bb4020cd05806fd0d33c44d38046b8bd7f0e40814b9763cabfc"
 dependencies = [
  "serde",
 ]
@@ -733,9 +733,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.86"
+version = "1.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f9fa1897e4325be0d68d48df6aa1a71ac2ed4d27723887e7754192705350730"
+checksum = "8cd6604a82acf3039f1144f54b8eb34e91ffba622051189e71b781822d5ee1f5"
 
 [[package]]
 name = "cfg-if"
@@ -751,15 +751,15 @@ checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
 name = "chrono"
-version = "0.4.34"
+version = "0.4.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bc015644b92d5890fab7489e49d21f879d5c990186827d42ec511919404f38b"
+checksum = "8a0d04d43504c61aa6c7531f1871dd0d418d91130162063b789da00fd7057a5e"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
  "num-traits",
  "serde",
- "windows-targets 0.52.0",
+ "windows-targets 0.52.4",
 ]
 
 [[package]]
@@ -786,7 +786,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
 dependencies = [
  "ciborium-io",
- "half 2.3.1",
+ "half 2.4.0",
 ]
 
 [[package]]
@@ -827,19 +827,19 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.1"
+version = "4.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c918d541ef2913577a0f9566e9ce27cb35b6df072075769e0b26cb5a554520da"
+checksum = "90bc066a67923782aa8515dbaea16946c5bcc5addbd668bb80af688e53e548a0"
 dependencies = [
  "clap_builder",
- "clap_derive 4.5.0",
+ "clap_derive 4.5.4",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.1"
+version = "4.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f3e7391dad68afb0c2ede1bf619f579a3dc9c2ec67f089baa397123a2f3d1eb"
+checksum = "ae129e2e766ae0ec03484e609954119f123cc1fe650337e155d03b022f24f7b4"
 dependencies = [
  "anstream",
  "anstyle",
@@ -853,7 +853,7 @@ version = "3.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae6371b8bdc8b7d3959e9cf7b22d4435ef3e79e138688421ec654acf8c81b008"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro-error",
  "proc-macro2",
  "quote",
@@ -862,14 +862,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.0"
+version = "4.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "307bc0538d5f0f83b8248db3087aa92fe504e4691294d0c96c0eabc33f47ba47"
+checksum = "528131438037fd55894f62d6e9f068b8f45ac57ffa77517819645d10aed04f64"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -1017,9 +1017,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.11"
+version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "176dc175b78f56c0f321911d9c8eb2b77a78a4860b9c19db83835fea1a46649b"
+checksum = "ab3db02a9c5b5121e1e42fbdb1aeb65f5e02624cc58c43f2884c6ccac0b82f95"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -1043,7 +1043,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef2b4b23cddf68b89b8f8069890e8c270d54e2d5fe1b143820234805e4cb17ef"
 dependencies = [
  "generic-array",
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
  "zeroize",
 ]
@@ -1055,7 +1055,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
  "generic-array",
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
  "zeroize",
 ]
@@ -1067,7 +1067,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
- "rand_core 0.6.4",
+ "rand_core",
  "typenum",
 ]
 
@@ -1113,15 +1113,30 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "3.2.0"
+version = "4.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b9fdf9972b2bd6af2d913799d9ebc165ea4d2e65878e329d9c6b372c4491b61"
+checksum = "e89b8c6a2e4b1f45971ad09761aafb85514a84744b67a95e32c3cc1352d1f65c"
 dependencies = [
- "byteorder",
- "digest 0.9.0",
- "rand_core 0.5.1",
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "digest 0.10.7",
+ "fiat-crypto",
+ "platforms",
+ "rustc_version",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -1132,7 +1147,7 @@ checksum = "1c359b7249347e46fb28804470d071c921156ad62b3eef5d34e2ba867533dec8"
 dependencies = [
  "byteorder",
  "digest 0.9.0",
- "rand_core 0.6.4",
+ "rand_core",
  "subtle-ng",
  "zeroize",
 ]
@@ -1140,7 +1155,7 @@ dependencies = [
 [[package]]
 name = "cycles-minting-canister"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5fe907da2193c6051634b29133280f53f2490d52#5fe907da2193c6051634b29133280f53f2490d52"
+source = "git+https://github.com/dfinity/ic?rev=7622861bcb3ccbdf52c9ff0bf692516fb1957072#7622861bcb3ccbdf52c9ff0bf692516fb1957072"
 dependencies = [
  "async-trait",
  "base64 0.13.1",
@@ -1300,7 +1315,7 @@ dependencies = [
 [[package]]
 name = "dfn_candid"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5fe907da2193c6051634b29133280f53f2490d52#5fe907da2193c6051634b29133280f53f2490d52"
+source = "git+https://github.com/dfinity/ic?rev=7622861bcb3ccbdf52c9ff0bf692516fb1957072#7622861bcb3ccbdf52c9ff0bf692516fb1957072"
 dependencies = [
  "candid",
  "dfn_core",
@@ -1312,7 +1327,7 @@ dependencies = [
 [[package]]
 name = "dfn_core"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5fe907da2193c6051634b29133280f53f2490d52#5fe907da2193c6051634b29133280f53f2490d52"
+source = "git+https://github.com/dfinity/ic?rev=7622861bcb3ccbdf52c9ff0bf692516fb1957072#7622861bcb3ccbdf52c9ff0bf692516fb1957072"
 dependencies = [
  "ic-base-types",
  "on_wire",
@@ -1321,7 +1336,7 @@ dependencies = [
 [[package]]
 name = "dfn_http"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5fe907da2193c6051634b29133280f53f2490d52#5fe907da2193c6051634b29133280f53f2490d52"
+source = "git+https://github.com/dfinity/ic?rev=7622861bcb3ccbdf52c9ff0bf692516fb1957072#7622861bcb3ccbdf52c9ff0bf692516fb1957072"
 dependencies = [
  "candid",
  "dfn_candid",
@@ -1333,7 +1348,7 @@ dependencies = [
 [[package]]
 name = "dfn_http_metrics"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5fe907da2193c6051634b29133280f53f2490d52#5fe907da2193c6051634b29133280f53f2490d52"
+source = "git+https://github.com/dfinity/ic?rev=7622861bcb3ccbdf52c9ff0bf692516fb1957072#7622861bcb3ccbdf52c9ff0bf692516fb1957072"
 dependencies = [
  "dfn_candid",
  "dfn_core",
@@ -1345,7 +1360,7 @@ dependencies = [
 [[package]]
 name = "dfn_protobuf"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5fe907da2193c6051634b29133280f53f2490d52#5fe907da2193c6051634b29133280f53f2490d52"
+source = "git+https://github.com/dfinity/ic?rev=7622861bcb3ccbdf52c9ff0bf692516fb1957072#7622861bcb3ccbdf52c9ff0bf692516fb1957072"
 dependencies = [
  "on_wire",
  "prost",
@@ -1362,7 +1377,7 @@ dependencies = [
  "byte-unit",
  "bytes",
  "candid",
- "clap 4.5.1",
+ "clap 4.5.4",
  "dialoguer",
  "directories-next",
  "dunce",
@@ -1501,7 +1516,7 @@ checksum = "487585f4d0c6655fe74905e2504d8ad6908e4db67f744eb140876906c2f3175d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -1518,9 +1533,9 @@ checksum = "56ce8c6da7551ec6c462cbaf3bfbc75131ebbfa1c944aeaa9dab51ca1c5f0c3b"
 
 [[package]]
 name = "dyn-clone"
-version = "1.0.16"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "545b22097d44f8a9581187cdf93de7a71e4722bf51200cfaba810865b49a495d"
+checksum = "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125"
 
 [[package]]
 name = "ecdsa"
@@ -1549,6 +1564,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "pkcs8 0.10.2",
+ "signature 2.2.0",
+]
+
+[[package]]
 name = "ed25519-consensus"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1556,10 +1581,27 @@ checksum = "3c8465edc8ee7436ffea81d21a019b16676ee3db267aa8d5a8d729581ecf998b"
 dependencies = [
  "curve25519-dalek-ng",
  "hex",
- "rand_core 0.6.4",
+ "rand_core",
  "serde",
  "sha2 0.9.9",
  "thiserror",
+ "zeroize",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a3daa8e81a3963a60642bcc1f90a670680bd4a77535faa384e9d1c79d620871"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "merlin",
+ "rand_core",
+ "serde",
+ "sha2 0.10.8",
+ "signature 2.2.0",
+ "subtle",
  "zeroize",
 ]
 
@@ -1584,7 +1626,7 @@ dependencies = [
  "group 0.12.1",
  "pem-rfc7468 0.6.0",
  "pkcs8 0.9.0",
- "rand_core 0.6.4",
+ "rand_core",
  "sec1 0.3.0",
  "subtle",
  "zeroize",
@@ -1604,7 +1646,7 @@ dependencies = [
  "group 0.13.0",
  "pem-rfc7468 0.7.0",
  "pkcs8 0.10.2",
- "rand_core 0.6.4",
+ "rand_core",
  "sec1 0.7.3",
  "subtle",
  "zeroize",
@@ -1688,14 +1730,14 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.0.1"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
+checksum = "658bd65b1cf4c852a3cc96f18a8ce7b5640f6b703f905c7d74532294c2a63984"
 
 [[package]]
 name = "fe-derive"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5fe907da2193c6051634b29133280f53f2490d52#5fe907da2193c6051634b29133280f53f2490d52"
+source = "git+https://github.com/dfinity/ic?rev=7622861bcb3ccbdf52c9ff0bf692516fb1957072#7622861bcb3ccbdf52c9ff0bf692516fb1957072"
 dependencies = [
  "hex",
  "num-bigint-dig",
@@ -1711,7 +1753,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d013fc25338cc558c5c2cfbad646908fb23591e2404481826742b651c9af7160"
 dependencies = [
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
 ]
 
@@ -1721,9 +1763,15 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
 dependencies = [
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
 ]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c007b1ae3abe1cb6f85a16305acd418b7ca6343b953633fee2b76d8f108b830f"
 
 [[package]]
 name = "filetime"
@@ -1771,7 +1819,7 @@ checksum = "2cd66269887534af4b0c3e3337404591daa8dc8b9b2b3db71f9523beb4bafb41"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -1887,7 +1935,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -1933,31 +1981,20 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi 0.9.0+wasi-snapshot-preview1",
-]
-
-[[package]]
-name = "getrandom"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
 ]
 
 [[package]]
 name = "ghash"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d930750de5717d2dd0b8c0d42c076c0e884c81a73e6cab859bbd2339c71e3e40"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
 dependencies = [
  "opaque-debug",
  "polyval",
@@ -1982,7 +2019,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dfbfb3a6cfbd390d5c9564ab283a0349b9b9fcd46a706c1eb10e0db70bfbac7"
 dependencies = [
  "ff 0.12.1",
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
 ]
 
@@ -1993,15 +2030,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff 0.13.0",
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
 ]
 
 [[package]]
 name = "h2"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb2c4422095b67ee78da96fbb51a4cc413b3b25883c7717ff7ca1ab31022c9c9"
+checksum = "4fbd2820c5e49886948654ab546d0688ff24530286bdcf8fca3cefb16d4618eb"
 dependencies = [
  "bytes",
  "fnv",
@@ -2009,7 +2046,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http",
- "indexmap 2.2.3",
+ "indexmap 2.2.6",
  "slab",
  "tokio",
  "tokio-util",
@@ -2018,15 +2055,15 @@ dependencies = [
 
 [[package]]
 name = "half"
-version = "1.8.2"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
+checksum = "1b43ede17f21864e81be2fa654110bf1e793774238d86ef8555c37e6519c0403"
 
 [[package]]
 name = "half"
-version = "2.3.1"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc52e53916c08643f1b56ec082790d1e86a32e58dc5268f897f313fbae7b4872"
+checksum = "b5eceaaeec696539ddaf7b333340f1af35a5aa87ae3e4f3ead0532f72affab2e"
 dependencies = [
  "cfg-if",
  "crunchy",
@@ -2047,7 +2084,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 dependencies = [
- "ahash 0.8.9",
+ "ahash 0.8.11",
  "allocator-api2",
 ]
 
@@ -2056,6 +2093,12 @@ name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
@@ -2068,9 +2111,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.6"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd5256b483761cd23699d0da46cc6fd2ee3be420bbe6d020ae4a091e70b7e9fd"
+checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "hex"
@@ -2127,9 +2170,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8947b1a6fad4393052c7ba1f4cd97bed3e953a95c79c92ad9b051a04611d9fbb"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
 dependencies = [
  "bytes",
  "fnv",
@@ -2192,7 +2235,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.5.5",
+ "socket2 0.5.6",
  "tokio",
  "tower-service",
  "tracing",
@@ -2308,7 +2351,7 @@ dependencies = [
 [[package]]
 name = "ic-base-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5fe907da2193c6051634b29133280f53f2490d52#5fe907da2193c6051634b29133280f53f2490d52"
+source = "git+https://github.com/dfinity/ic?rev=7622861bcb3ccbdf52c9ff0bf692516fb1957072#7622861bcb3ccbdf52c9ff0bf692516fb1957072"
 dependencies = [
  "byte-unit",
  "bytes",
@@ -2316,7 +2359,6 @@ dependencies = [
  "comparable",
  "ic-crypto-sha2",
  "ic-protobuf",
- "ic-stable-structures",
  "phantom_newtype",
  "prost",
  "serde",
@@ -2324,8 +2366,8 @@ dependencies = [
 
 [[package]]
 name = "ic-btc-interface"
-version = "0.1.0"
-source = "git+https://github.com/dfinity/bitcoin-canister?rev=9b239d1d67253eb14a35be6061e3967d5ec9db9d#9b239d1d67253eb14a35be6061e3967d5ec9db9d"
+version = "0.2.0"
+source = "git+https://github.com/dfinity/bitcoin-canister?rev=62a71e47c491fb842ccc257b1c675651501f4b82#62a71e47c491fb842ccc257b1c675651501f4b82"
 dependencies = [
  "candid",
  "serde",
@@ -2335,7 +2377,7 @@ dependencies = [
 [[package]]
 name = "ic-btc-types-internal"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5fe907da2193c6051634b29133280f53f2490d52#5fe907da2193c6051634b29133280f53f2490d52"
+source = "git+https://github.com/dfinity/ic?rev=7622861bcb3ccbdf52c9ff0bf692516fb1957072#7622861bcb3ccbdf52c9ff0bf692516fb1957072"
 dependencies = [
  "candid",
  "ic-btc-interface",
@@ -2348,13 +2390,11 @@ dependencies = [
 [[package]]
 name = "ic-canister-client-sender"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5fe907da2193c6051634b29133280f53f2490d52#5fe907da2193c6051634b29133280f53f2490d52"
+source = "git+https://github.com/dfinity/ic?rev=7622861bcb3ccbdf52c9ff0bf692516fb1957072#7622861bcb3ccbdf52c9ff0bf692516fb1957072"
 dependencies = [
- "ed25519-consensus",
  "ic-base-types",
  "ic-crypto-ecdsa-secp256k1",
- "ic-crypto-internal-types",
- "ic-crypto-utils-basic-sig",
+ "ic-crypto-ed25519",
  "ic-types",
  "rand",
  "rand_chacha",
@@ -2363,7 +2403,7 @@ dependencies = [
 [[package]]
 name = "ic-canister-log"
 version = "0.2.0"
-source = "git+https://github.com/dfinity/ic?rev=5fe907da2193c6051634b29133280f53f2490d52#5fe907da2193c6051634b29133280f53f2490d52"
+source = "git+https://github.com/dfinity/ic?rev=7622861bcb3ccbdf52c9ff0bf692516fb1957072#7622861bcb3ccbdf52c9ff0bf692516fb1957072"
 dependencies = [
  "serde",
 ]
@@ -2371,7 +2411,7 @@ dependencies = [
 [[package]]
 name = "ic-canister-profiler"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5fe907da2193c6051634b29133280f53f2490d52#5fe907da2193c6051634b29133280f53f2490d52"
+source = "git+https://github.com/dfinity/ic?rev=7622861bcb3ccbdf52c9ff0bf692516fb1957072#7622861bcb3ccbdf52c9ff0bf692516fb1957072"
 dependencies = [
  "ic-metrics-encoder",
  "ic0 0.18.11",
@@ -2380,7 +2420,7 @@ dependencies = [
 [[package]]
 name = "ic-canisters-http-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5fe907da2193c6051634b29133280f53f2490d52#5fe907da2193c6051634b29133280f53f2490d52"
+source = "git+https://github.com/dfinity/ic?rev=7622861bcb3ccbdf52c9ff0bf692516fb1957072#7622861bcb3ccbdf52c9ff0bf692516fb1957072"
 dependencies = [
  "candid",
  "serde",
@@ -2389,9 +2429,9 @@ dependencies = [
 
 [[package]]
 name = "ic-cdk"
-version = "0.12.1"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f3d204af0b11c45715169c997858edb58fa8407d08f4fae78a6b415dd39a362"
+checksum = "c63a6fceb94127bda86bd6d05f859a0e2a67d128a8ffb5ddab17e1f15ac8f555"
 dependencies = [
  "candid",
  "ic-cdk-macros",
@@ -2402,9 +2442,9 @@ dependencies = [
 
 [[package]]
 name = "ic-cdk-macros"
-version = "0.8.4"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5a618e4020cea88e933d8d2f8c7f86d570ec06213506a80d4f2c520a9bba512"
+checksum = "2fde5ca6ef1e69825c68916ff1bf7256b8f7ed69ac5ea3f1756f6e57f1503e27"
 dependencies = [
  "candid",
  "proc-macro2",
@@ -2416,9 +2456,9 @@ dependencies = [
 
 [[package]]
 name = "ic-cdk-timers"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c43b9706fef3ad10c4192a14801d16bd9539068239f0f06f257857441364329"
+checksum = "054727a3a1c486528b96349817d54290ff70df6addf417def456ea708a16f7fb"
 dependencies = [
  "futures",
  "ic-cdk",
@@ -2430,9 +2470,9 @@ dependencies = [
 
 [[package]]
 name = "ic-certification"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "480b6a64a6602ed8c4eac150ef72f2206dc2910069d0cf524b5c6f90d8bc03fc"
+checksum = "20052ce9255fbe2de7041a4f6996fddd095ba1f31ae83b6c0ccdee5be6e7bbcf"
 dependencies = [
  "hex",
  "serde",
@@ -2454,12 +2494,12 @@ dependencies = [
 [[package]]
 name = "ic-constants"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5fe907da2193c6051634b29133280f53f2490d52#5fe907da2193c6051634b29133280f53f2490d52"
+source = "git+https://github.com/dfinity/ic?rev=7622861bcb3ccbdf52c9ff0bf692516fb1957072#7622861bcb3ccbdf52c9ff0bf692516fb1957072"
 
 [[package]]
 name = "ic-crypto-ecdsa-secp256k1"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5fe907da2193c6051634b29133280f53f2490d52#5fe907da2193c6051634b29133280f53f2490d52"
+source = "git+https://github.com/dfinity/ic?rev=7622861bcb3ccbdf52c9ff0bf692516fb1957072#7622861bcb3ccbdf52c9ff0bf692516fb1957072"
 dependencies = [
  "k256 0.13.3",
  "lazy_static",
@@ -2471,28 +2511,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "ic-crypto-ed25519"
+version = "0.9.0"
+source = "git+https://github.com/dfinity/ic?rev=7622861bcb3ccbdf52c9ff0bf692516fb1957072#7622861bcb3ccbdf52c9ff0bf692516fb1957072"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519-dalek",
+ "pem 1.1.1",
+ "rand",
+ "zeroize",
+]
+
+[[package]]
 name = "ic-crypto-getrandom-for-wasm"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5fe907da2193c6051634b29133280f53f2490d52#5fe907da2193c6051634b29133280f53f2490d52"
+source = "git+https://github.com/dfinity/ic?rev=7622861bcb3ccbdf52c9ff0bf692516fb1957072#7622861bcb3ccbdf52c9ff0bf692516fb1957072"
 dependencies = [
- "getrandom 0.2.12",
+ "getrandom",
 ]
 
 [[package]]
 name = "ic-crypto-internal-basic-sig-der-utils"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5fe907da2193c6051634b29133280f53f2490d52#5fe907da2193c6051634b29133280f53f2490d52"
+source = "git+https://github.com/dfinity/ic?rev=7622861bcb3ccbdf52c9ff0bf692516fb1957072#7622861bcb3ccbdf52c9ff0bf692516fb1957072"
 dependencies = [
  "hex",
  "ic-types",
  "simple_asn1",
- "zeroize",
 ]
 
 [[package]]
 name = "ic-crypto-internal-basic-sig-ed25519"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5fe907da2193c6051634b29133280f53f2490d52#5fe907da2193c6051634b29133280f53f2490d52"
+source = "git+https://github.com/dfinity/ic?rev=7622861bcb3ccbdf52c9ff0bf692516fb1957072#7622861bcb3ccbdf52c9ff0bf692516fb1957072"
 dependencies = [
  "base64 0.13.1",
  "curve25519-dalek",
@@ -2514,7 +2565,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-bls12-381-type"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5fe907da2193c6051634b29133280f53f2490d52#5fe907da2193c6051634b29133280f53f2490d52"
+source = "git+https://github.com/dfinity/ic?rev=7622861bcb3ccbdf52c9ff0bf692516fb1957072#7622861bcb3ccbdf52c9ff0bf692516fb1957072"
 dependencies = [
  "hex",
  "ic_bls12_381",
@@ -2532,7 +2583,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-hmac"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5fe907da2193c6051634b29133280f53f2490d52#5fe907da2193c6051634b29133280f53f2490d52"
+source = "git+https://github.com/dfinity/ic?rev=7622861bcb3ccbdf52c9ff0bf692516fb1957072#7622861bcb3ccbdf52c9ff0bf692516fb1957072"
 dependencies = [
  "ic-crypto-internal-sha2",
 ]
@@ -2540,7 +2591,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-multi-sig-bls12381"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5fe907da2193c6051634b29133280f53f2490d52#5fe907da2193c6051634b29133280f53f2490d52"
+source = "git+https://github.com/dfinity/ic?rev=7622861bcb3ccbdf52c9ff0bf692516fb1957072#7622861bcb3ccbdf52c9ff0bf692516fb1957072"
 dependencies = [
  "base64 0.13.1",
  "hex",
@@ -2559,7 +2610,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-seed"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5fe907da2193c6051634b29133280f53f2490d52#5fe907da2193c6051634b29133280f53f2490d52"
+source = "git+https://github.com/dfinity/ic?rev=7622861bcb3ccbdf52c9ff0bf692516fb1957072#7622861bcb3ccbdf52c9ff0bf692516fb1957072"
 dependencies = [
  "hex",
  "ic-crypto-sha2",
@@ -2572,7 +2623,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-sha2"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5fe907da2193c6051634b29133280f53f2490d52#5fe907da2193c6051634b29133280f53f2490d52"
+source = "git+https://github.com/dfinity/ic?rev=7622861bcb3ccbdf52c9ff0bf692516fb1957072#7622861bcb3ccbdf52c9ff0bf692516fb1957072"
 dependencies = [
  "sha2 0.10.8",
 ]
@@ -2580,14 +2631,13 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-threshold-sig-bls12381"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5fe907da2193c6051634b29133280f53f2490d52#5fe907da2193c6051634b29133280f53f2490d52"
+source = "git+https://github.com/dfinity/ic?rev=7622861bcb3ccbdf52c9ff0bf692516fb1957072#7622861bcb3ccbdf52c9ff0bf692516fb1957072"
 dependencies = [
  "base64 0.13.1",
  "cached 0.41.0",
  "hex",
  "ic-crypto-internal-bls12-381-type",
  "ic-crypto-internal-seed",
- "ic-crypto-internal-threshold-sig-bls12381-der",
  "ic-crypto-internal-types",
  "ic-crypto-secrets-containers",
  "ic-crypto-sha2",
@@ -2599,23 +2649,15 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_cbor",
- "strum_macros 0.25.3",
+ "strum_macros 0.26.2",
  "subtle",
  "zeroize",
 ]
 
 [[package]]
-name = "ic-crypto-internal-threshold-sig-bls12381-der"
-version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5fe907da2193c6051634b29133280f53f2490d52#5fe907da2193c6051634b29133280f53f2490d52"
-dependencies = [
- "simple_asn1",
-]
-
-[[package]]
 name = "ic-crypto-internal-threshold-sig-ecdsa"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5fe907da2193c6051634b29133280f53f2490d52#5fe907da2193c6051634b29133280f53f2490d52"
+source = "git+https://github.com/dfinity/ic?rev=7622861bcb3ccbdf52c9ff0bf692516fb1957072#7622861bcb3ccbdf52c9ff0bf692516fb1957072"
 dependencies = [
  "fe-derive",
  "hex",
@@ -2634,8 +2676,8 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_cbor",
- "strum 0.25.0",
- "strum_macros 0.25.3",
+ "strum 0.26.2",
+ "strum_macros 0.26.2",
  "subtle",
  "zeroize",
 ]
@@ -2643,7 +2685,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5fe907da2193c6051634b29133280f53f2490d52#5fe907da2193c6051634b29133280f53f2490d52"
+source = "git+https://github.com/dfinity/ic?rev=7622861bcb3ccbdf52c9ff0bf692516fb1957072#7622861bcb3ccbdf52c9ff0bf692516fb1957072"
 dependencies = [
  "arrayvec 0.7.4",
  "hex",
@@ -2651,8 +2693,8 @@ dependencies = [
  "phantom_newtype",
  "serde",
  "serde_cbor",
- "strum 0.25.0",
- "strum_macros 0.25.3",
+ "strum 0.26.2",
+ "strum_macros 0.26.2",
  "thiserror",
  "zeroize",
 ]
@@ -2660,7 +2702,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-node-key-validation"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5fe907da2193c6051634b29133280f53f2490d52#5fe907da2193c6051634b29133280f53f2490d52"
+source = "git+https://github.com/dfinity/ic?rev=7622861bcb3ccbdf52c9ff0bf692516fb1957072#7622861bcb3ccbdf52c9ff0bf692516fb1957072"
 dependencies = [
  "hex",
  "ic-base-types",
@@ -2678,7 +2720,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-secrets-containers"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5fe907da2193c6051634b29133280f53f2490d52#5fe907da2193c6051634b29133280f53f2490d52"
+source = "git+https://github.com/dfinity/ic?rev=7622861bcb3ccbdf52c9ff0bf692516fb1957072#7622861bcb3ccbdf52c9ff0bf692516fb1957072"
 dependencies = [
  "serde",
  "zeroize",
@@ -2687,7 +2729,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-sha2"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5fe907da2193c6051634b29133280f53f2490d52#5fe907da2193c6051634b29133280f53f2490d52"
+source = "git+https://github.com/dfinity/ic?rev=7622861bcb3ccbdf52c9ff0bf692516fb1957072#7622861bcb3ccbdf52c9ff0bf692516fb1957072"
 dependencies = [
  "ic-crypto-internal-sha2",
 ]
@@ -2695,7 +2737,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-test-utils-reproducible-rng"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5fe907da2193c6051634b29133280f53f2490d52#5fe907da2193c6051634b29133280f53f2490d52"
+source = "git+https://github.com/dfinity/ic?rev=7622861bcb3ccbdf52c9ff0bf692516fb1957072#7622861bcb3ccbdf52c9ff0bf692516fb1957072"
 dependencies = [
  "rand",
  "rand_chacha",
@@ -2704,7 +2746,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-tls-cert-validation"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5fe907da2193c6051634b29133280f53f2490d52#5fe907da2193c6051634b29133280f53f2490d52"
+source = "git+https://github.com/dfinity/ic?rev=7622861bcb3ccbdf52c9ff0bf692516fb1957072#7622861bcb3ccbdf52c9ff0bf692516fb1957072"
 dependencies = [
  "hex",
  "ic-crypto-internal-basic-sig-ed25519",
@@ -2718,7 +2760,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-tree-hash"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5fe907da2193c6051634b29133280f53f2490d52#5fe907da2193c6051634b29133280f53f2490d52"
+source = "git+https://github.com/dfinity/ic?rev=7622861bcb3ccbdf52c9ff0bf692516fb1957072#7622861bcb3ccbdf52c9ff0bf692516fb1957072"
 dependencies = [
  "assert_matches",
  "ic-crypto-internal-types",
@@ -2732,22 +2774,17 @@ dependencies = [
 [[package]]
 name = "ic-crypto-utils-basic-sig"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5fe907da2193c6051634b29133280f53f2490d52#5fe907da2193c6051634b29133280f53f2490d52"
+source = "git+https://github.com/dfinity/ic?rev=7622861bcb3ccbdf52c9ff0bf692516fb1957072#7622861bcb3ccbdf52c9ff0bf692516fb1957072"
 dependencies = [
- "base64 0.13.1",
- "ed25519-consensus",
  "ic-base-types",
- "ic-crypto-internal-basic-sig-der-utils",
- "ic-crypto-internal-basic-sig-ed25519",
- "ic-crypto-internal-types",
+ "ic-crypto-ed25519",
  "ic-protobuf",
- "simple_asn1",
 ]
 
 [[package]]
 name = "ic-crypto-utils-ni-dkg"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=5fe907da2193c6051634b29133280f53f2490d52#5fe907da2193c6051634b29133280f53f2490d52"
+source = "git+https://github.com/dfinity/ic?rev=7622861bcb3ccbdf52c9ff0bf692516fb1957072#7622861bcb3ccbdf52c9ff0bf692516fb1957072"
 dependencies = [
  "ic-crypto-internal-types",
  "ic-protobuf",
@@ -2757,18 +2794,18 @@ dependencies = [
 [[package]]
 name = "ic-error-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5fe907da2193c6051634b29133280f53f2490d52#5fe907da2193c6051634b29133280f53f2490d52"
+source = "git+https://github.com/dfinity/ic?rev=7622861bcb3ccbdf52c9ff0bf692516fb1957072#7622861bcb3ccbdf52c9ff0bf692516fb1957072"
 dependencies = [
  "ic-utils 0.9.0",
  "serde",
- "strum 0.25.0",
- "strum_macros 0.25.3",
+ "strum 0.26.2",
+ "strum_macros 0.26.2",
 ]
 
 [[package]]
 name = "ic-icrc1"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5fe907da2193c6051634b29133280f53f2490d52#5fe907da2193c6051634b29133280f53f2490d52"
+source = "git+https://github.com/dfinity/ic?rev=7622861bcb3ccbdf52c9ff0bf692516fb1957072#7622861bcb3ccbdf52c9ff0bf692516fb1957072"
 dependencies = [
  "candid",
  "ciborium",
@@ -2790,7 +2827,7 @@ dependencies = [
 [[package]]
 name = "ic-icrc1-index-ng"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5fe907da2193c6051634b29133280f53f2490d52#5fe907da2193c6051634b29133280f53f2490d52"
+source = "git+https://github.com/dfinity/ic?rev=7622861bcb3ccbdf52c9ff0bf692516fb1957072#7622861bcb3ccbdf52c9ff0bf692516fb1957072"
 dependencies = [
  "candid",
  "ciborium",
@@ -2817,7 +2854,7 @@ dependencies = [
 [[package]]
 name = "ic-icrc1-ledger"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5fe907da2193c6051634b29133280f53f2490d52#5fe907da2193c6051634b29133280f53f2490d52"
+source = "git+https://github.com/dfinity/ic?rev=7622861bcb3ccbdf52c9ff0bf692516fb1957072#7622861bcb3ccbdf52c9ff0bf692516fb1957072"
 dependencies = [
  "async-trait",
  "candid",
@@ -2845,7 +2882,7 @@ dependencies = [
 [[package]]
 name = "ic-icrc1-tokens-u64"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=5fe907da2193c6051634b29133280f53f2490d52#5fe907da2193c6051634b29133280f53f2490d52"
+source = "git+https://github.com/dfinity/ic?rev=7622861bcb3ccbdf52c9ff0bf692516fb1957072#7622861bcb3ccbdf52c9ff0bf692516fb1957072"
 dependencies = [
  "candid",
  "ic-ledger-core",
@@ -2871,7 +2908,7 @@ dependencies = [
 [[package]]
 name = "ic-ledger-canister-core"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5fe907da2193c6051634b29133280f53f2490d52#5fe907da2193c6051634b29133280f53f2490d52"
+source = "git+https://github.com/dfinity/ic?rev=7622861bcb3ccbdf52c9ff0bf692516fb1957072#7622861bcb3ccbdf52c9ff0bf692516fb1957072"
 dependencies = [
  "async-trait",
  "candid",
@@ -2889,7 +2926,7 @@ dependencies = [
 [[package]]
 name = "ic-ledger-core"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5fe907da2193c6051634b29133280f53f2490d52#5fe907da2193c6051634b29133280f53f2490d52"
+source = "git+https://github.com/dfinity/ic?rev=7622861bcb3ccbdf52c9ff0bf692516fb1957072#7622861bcb3ccbdf52c9ff0bf692516fb1957072"
 dependencies = [
  "candid",
  "ic-ledger-hash-of",
@@ -2901,7 +2938,7 @@ dependencies = [
 [[package]]
 name = "ic-ledger-hash-of"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=5fe907da2193c6051634b29133280f53f2490d52#5fe907da2193c6051634b29133280f53f2490d52"
+source = "git+https://github.com/dfinity/ic?rev=7622861bcb3ccbdf52c9ff0bf692516fb1957072#7622861bcb3ccbdf52c9ff0bf692516fb1957072"
 dependencies = [
  "candid",
  "hex",
@@ -2911,7 +2948,7 @@ dependencies = [
 [[package]]
 name = "ic-management-canister-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5fe907da2193c6051634b29133280f53f2490d52#5fe907da2193c6051634b29133280f53f2490d52"
+source = "git+https://github.com/dfinity/ic?rev=7622861bcb3ccbdf52c9ff0bf692516fb1957072#7622861bcb3ccbdf52c9ff0bf692516fb1957072"
 dependencies = [
  "candid",
  "ic-base-types",
@@ -2923,8 +2960,8 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_cbor",
- "strum 0.25.0",
- "strum_macros 0.25.3",
+ "strum 0.26.2",
+ "strum_macros 0.26.2",
 ]
 
 [[package]]
@@ -2936,7 +2973,7 @@ checksum = "8b5c7628eac357aecda461130f8074468be5aa4d258a002032d82d817f79f1f8"
 [[package]]
 name = "ic-nervous-system-clients"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=5fe907da2193c6051634b29133280f53f2490d52#5fe907da2193c6051634b29133280f53f2490d52"
+source = "git+https://github.com/dfinity/ic?rev=7622861bcb3ccbdf52c9ff0bf692516fb1957072#7622861bcb3ccbdf52c9ff0bf692516fb1957072"
 dependencies = [
  "async-trait",
  "candid",
@@ -2953,12 +2990,12 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-collections-union-multi-map"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=5fe907da2193c6051634b29133280f53f2490d52#5fe907da2193c6051634b29133280f53f2490d52"
+source = "git+https://github.com/dfinity/ic?rev=7622861bcb3ccbdf52c9ff0bf692516fb1957072#7622861bcb3ccbdf52c9ff0bf692516fb1957072"
 
 [[package]]
 name = "ic-nervous-system-common"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5fe907da2193c6051634b29133280f53f2490d52#5fe907da2193c6051634b29133280f53f2490d52"
+source = "git+https://github.com/dfinity/ic?rev=7622861bcb3ccbdf52c9ff0bf692516fb1957072#7622861bcb3ccbdf52c9ff0bf692516fb1957072"
 dependencies = [
  "async-trait",
  "build-info",
@@ -2993,12 +3030,12 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-common-build-metadata"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5fe907da2193c6051634b29133280f53f2490d52#5fe907da2193c6051634b29133280f53f2490d52"
+source = "git+https://github.com/dfinity/ic?rev=7622861bcb3ccbdf52c9ff0bf692516fb1957072#7622861bcb3ccbdf52c9ff0bf692516fb1957072"
 
 [[package]]
 name = "ic-nervous-system-common-test-keys"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5fe907da2193c6051634b29133280f53f2490d52#5fe907da2193c6051634b29133280f53f2490d52"
+source = "git+https://github.com/dfinity/ic?rev=7622861bcb3ccbdf52c9ff0bf692516fb1957072#7622861bcb3ccbdf52c9ff0bf692516fb1957072"
 dependencies = [
  "ic-base-types",
  "ic-canister-client-sender",
@@ -3011,10 +3048,11 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-governance"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=5fe907da2193c6051634b29133280f53f2490d52#5fe907da2193c6051634b29133280f53f2490d52"
+source = "git+https://github.com/dfinity/ic?rev=7622861bcb3ccbdf52c9ff0bf692516fb1957072#7622861bcb3ccbdf52c9ff0bf692516fb1957072"
 dependencies = [
  "ic-base-types",
  "ic-stable-structures",
+ "ic_principal",
  "maplit",
  "num-traits",
 ]
@@ -3022,7 +3060,7 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-humanize"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5fe907da2193c6051634b29133280f53f2490d52#5fe907da2193c6051634b29133280f53f2490d52"
+source = "git+https://github.com/dfinity/ic?rev=7622861bcb3ccbdf52c9ff0bf692516fb1957072#7622861bcb3ccbdf52c9ff0bf692516fb1957072"
 dependencies = [
  "humantime",
  "ic-nervous-system-proto",
@@ -3032,9 +3070,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "ic-nervous-system-lock"
+version = "0.0.1"
+source = "git+https://github.com/dfinity/ic?rev=7622861bcb3ccbdf52c9ff0bf692516fb1957072#7622861bcb3ccbdf52c9ff0bf692516fb1957072"
+
+[[package]]
 name = "ic-nervous-system-proto"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5fe907da2193c6051634b29133280f53f2490d52#5fe907da2193c6051634b29133280f53f2490d52"
+source = "git+https://github.com/dfinity/ic?rev=7622861bcb3ccbdf52c9ff0bf692516fb1957072#7622861bcb3ccbdf52c9ff0bf692516fb1957072"
 dependencies = [
  "candid",
  "comparable",
@@ -3047,7 +3090,7 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-proxied-canister-calls-tracker"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5fe907da2193c6051634b29133280f53f2490d52#5fe907da2193c6051634b29133280f53f2490d52"
+source = "git+https://github.com/dfinity/ic?rev=7622861bcb3ccbdf52c9ff0bf692516fb1957072#7622861bcb3ccbdf52c9ff0bf692516fb1957072"
 dependencies = [
  "ic-base-types",
 ]
@@ -3055,7 +3098,7 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-root"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5fe907da2193c6051634b29133280f53f2490d52#5fe907da2193c6051634b29133280f53f2490d52"
+source = "git+https://github.com/dfinity/ic?rev=7622861bcb3ccbdf52c9ff0bf692516fb1957072#7622861bcb3ccbdf52c9ff0bf692516fb1957072"
 dependencies = [
  "candid",
  "dfn_core",
@@ -3071,7 +3114,7 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-runtime"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5fe907da2193c6051634b29133280f53f2490d52#5fe907da2193c6051634b29133280f53f2490d52"
+source = "git+https://github.com/dfinity/ic?rev=7622861bcb3ccbdf52c9ff0bf692516fb1957072#7622861bcb3ccbdf52c9ff0bf692516fb1957072"
 dependencies = [
  "async-trait",
  "candid",
@@ -3084,12 +3127,12 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-string"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=5fe907da2193c6051634b29133280f53f2490d52#5fe907da2193c6051634b29133280f53f2490d52"
+source = "git+https://github.com/dfinity/ic?rev=7622861bcb3ccbdf52c9ff0bf692516fb1957072#7622861bcb3ccbdf52c9ff0bf692516fb1957072"
 
 [[package]]
 name = "ic-neurons-fund"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=5fe907da2193c6051634b29133280f53f2490d52#5fe907da2193c6051634b29133280f53f2490d52"
+source = "git+https://github.com/dfinity/ic?rev=7622861bcb3ccbdf52c9ff0bf692516fb1957072#7622861bcb3ccbdf52c9ff0bf692516fb1957072"
 dependencies = [
  "ic-nervous-system-common",
  "lazy_static",
@@ -3102,7 +3145,7 @@ dependencies = [
 [[package]]
 name = "ic-nns-common"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5fe907da2193c6051634b29133280f53f2490d52#5fe907da2193c6051634b29133280f53f2490d52"
+source = "git+https://github.com/dfinity/ic?rev=7622861bcb3ccbdf52c9ff0bf692516fb1957072#7622861bcb3ccbdf52c9ff0bf692516fb1957072"
 dependencies = [
  "candid",
  "comparable",
@@ -3127,7 +3170,7 @@ dependencies = [
 [[package]]
 name = "ic-nns-constants"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5fe907da2193c6051634b29133280f53f2490d52#5fe907da2193c6051634b29133280f53f2490d52"
+source = "git+https://github.com/dfinity/ic?rev=7622861bcb3ccbdf52c9ff0bf692516fb1957072#7622861bcb3ccbdf52c9ff0bf692516fb1957072"
 dependencies = [
  "ic-base-types",
 ]
@@ -3135,7 +3178,7 @@ dependencies = [
 [[package]]
 name = "ic-nns-governance"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5fe907da2193c6051634b29133280f53f2490d52#5fe907da2193c6051634b29133280f53f2490d52"
+source = "git+https://github.com/dfinity/ic?rev=7622861bcb3ccbdf52c9ff0bf692516fb1957072#7622861bcb3ccbdf52c9ff0bf692516fb1957072"
 dependencies = [
  "async-trait",
  "build-info",
@@ -3190,19 +3233,19 @@ dependencies = [
  "rust_decimal_macros",
  "serde",
  "serde_json",
- "strum 0.25.0",
- "strum_macros 0.25.3",
+ "strum 0.26.2",
+ "strum_macros 0.26.2",
 ]
 
 [[package]]
 name = "ic-nns-gtc-accounts"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5fe907da2193c6051634b29133280f53f2490d52#5fe907da2193c6051634b29133280f53f2490d52"
+source = "git+https://github.com/dfinity/ic?rev=7622861bcb3ccbdf52c9ff0bf692516fb1957072#7622861bcb3ccbdf52c9ff0bf692516fb1957072"
 
 [[package]]
 name = "ic-nns-handler-root-interface"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=5fe907da2193c6051634b29133280f53f2490d52#5fe907da2193c6051634b29133280f53f2490d52"
+source = "git+https://github.com/dfinity/ic?rev=7622861bcb3ccbdf52c9ff0bf692516fb1957072#7622861bcb3ccbdf52c9ff0bf692516fb1957072"
 dependencies = [
  "async-trait",
  "candid",
@@ -3217,7 +3260,7 @@ dependencies = [
 [[package]]
 name = "ic-protobuf"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5fe907da2193c6051634b29133280f53f2490d52#5fe907da2193c6051634b29133280f53f2490d52"
+source = "git+https://github.com/dfinity/ic?rev=7622861bcb3ccbdf52c9ff0bf692516fb1957072#7622861bcb3ccbdf52c9ff0bf692516fb1957072"
 dependencies = [
  "bincode",
  "candid",
@@ -3232,7 +3275,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-keys"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5fe907da2193c6051634b29133280f53f2490d52#5fe907da2193c6051634b29133280f53f2490d52"
+source = "git+https://github.com/dfinity/ic?rev=7622861bcb3ccbdf52c9ff0bf692516fb1957072#7622861bcb3ccbdf52c9ff0bf692516fb1957072"
 dependencies = [
  "candid",
  "ic-base-types",
@@ -3244,7 +3287,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-routing-table"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5fe907da2193c6051634b29133280f53f2490d52#5fe907da2193c6051634b29133280f53f2490d52"
+source = "git+https://github.com/dfinity/ic?rev=7622861bcb3ccbdf52c9ff0bf692516fb1957072#7622861bcb3ccbdf52c9ff0bf692516fb1957072"
 dependencies = [
  "candid",
  "ic-base-types",
@@ -3255,7 +3298,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-subnet-features"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5fe907da2193c6051634b29133280f53f2490d52#5fe907da2193c6051634b29133280f53f2490d52"
+source = "git+https://github.com/dfinity/ic?rev=7622861bcb3ccbdf52c9ff0bf692516fb1957072#7622861bcb3ccbdf52c9ff0bf692516fb1957072"
 dependencies = [
  "candid",
  "ic-management-canister-types",
@@ -3266,19 +3309,19 @@ dependencies = [
 [[package]]
 name = "ic-registry-subnet-type"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5fe907da2193c6051634b29133280f53f2490d52#5fe907da2193c6051634b29133280f53f2490d52"
+source = "git+https://github.com/dfinity/ic?rev=7622861bcb3ccbdf52c9ff0bf692516fb1957072#7622861bcb3ccbdf52c9ff0bf692516fb1957072"
 dependencies = [
  "candid",
  "ic-protobuf",
  "serde",
- "strum 0.25.0",
- "strum_macros 0.25.3",
+ "strum 0.26.2",
+ "strum_macros 0.26.2",
 ]
 
 [[package]]
 name = "ic-registry-transport"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5fe907da2193c6051634b29133280f53f2490d52#5fe907da2193c6051634b29133280f53f2490d52"
+source = "git+https://github.com/dfinity/ic?rev=7622861bcb3ccbdf52c9ff0bf692516fb1957072#7622861bcb3ccbdf52c9ff0bf692516fb1957072"
 dependencies = [
  "candid",
  "ic-base-types",
@@ -3290,14 +3333,15 @@ dependencies = [
 [[package]]
 name = "ic-sns-cli"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5fe907da2193c6051634b29133280f53f2490d52#5fe907da2193c6051634b29133280f53f2490d52"
+source = "git+https://github.com/dfinity/ic?rev=7622861bcb3ccbdf52c9ff0bf692516fb1957072#7622861bcb3ccbdf52c9ff0bf692516fb1957072"
 dependencies = [
  "anyhow",
  "base64 0.13.1",
  "candid",
- "clap 4.5.1",
+ "clap 4.5.4",
  "hex",
  "ic-base-types",
+ "ic-crypto-sha2",
  "ic-nervous-system-common",
  "ic-nervous-system-common-test-keys",
  "ic-nervous-system-humanize",
@@ -3320,7 +3364,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-governance"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5fe907da2193c6051634b29133280f53f2490d52#5fe907da2193c6051634b29133280f53f2490d52"
+source = "git+https://github.com/dfinity/ic?rev=7622861bcb3ccbdf52c9ff0bf692516fb1957072#7622861bcb3ccbdf52c9ff0bf692516fb1957072"
 dependencies = [
  "async-trait",
  "base64 0.13.1",
@@ -3346,14 +3390,15 @@ dependencies = [
  "ic-nervous-system-common",
  "ic-nervous-system-common-build-metadata",
  "ic-nervous-system-governance",
+ "ic-nervous-system-lock",
  "ic-nervous-system-proto",
  "ic-nervous-system-root",
  "ic-nervous-system-runtime",
  "ic-nns-constants",
  "ic-protobuf",
  "ic-sns-governance-proposal-criticality",
+ "ic-sns-governance-proposals-amount-total-limit",
  "ic-sns-governance-token-valuation",
- "ic-sns-governance-treasury-transfer-limit",
  "icp-ledger",
  "icrc-ledger-client",
  "icrc-ledger-types",
@@ -3367,22 +3412,33 @@ dependencies = [
  "rust_decimal",
  "rust_decimal_macros",
  "serde",
- "strum 0.25.0",
- "strum_macros 0.25.3",
+ "strum 0.26.2",
+ "strum_macros 0.26.2",
 ]
 
 [[package]]
 name = "ic-sns-governance-proposal-criticality"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=5fe907da2193c6051634b29133280f53f2490d52#5fe907da2193c6051634b29133280f53f2490d52"
+source = "git+https://github.com/dfinity/ic?rev=7622861bcb3ccbdf52c9ff0bf692516fb1957072#7622861bcb3ccbdf52c9ff0bf692516fb1957072"
 dependencies = [
  "ic-nervous-system-proto",
 ]
 
 [[package]]
+name = "ic-sns-governance-proposals-amount-total-limit"
+version = "0.0.1"
+source = "git+https://github.com/dfinity/ic?rev=7622861bcb3ccbdf52c9ff0bf692516fb1957072#7622861bcb3ccbdf52c9ff0bf692516fb1957072"
+dependencies = [
+ "ic-sns-governance-token-valuation",
+ "num-traits",
+ "rust_decimal",
+ "rust_decimal_macros",
+]
+
+[[package]]
 name = "ic-sns-governance-token-valuation"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=5fe907da2193c6051634b29133280f53f2490d52#5fe907da2193c6051634b29133280f53f2490d52"
+source = "git+https://github.com/dfinity/ic?rev=7622861bcb3ccbdf52c9ff0bf692516fb1957072#7622861bcb3ccbdf52c9ff0bf692516fb1957072"
 dependencies = [
  "async-trait",
  "candid",
@@ -3401,20 +3457,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "ic-sns-governance-treasury-transfer-limit"
-version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=5fe907da2193c6051634b29133280f53f2490d52#5fe907da2193c6051634b29133280f53f2490d52"
-dependencies = [
- "ic-sns-governance-token-valuation",
- "num-traits",
- "rust_decimal",
- "rust_decimal_macros",
-]
-
-[[package]]
 name = "ic-sns-init"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5fe907da2193c6051634b29133280f53f2490d52#5fe907da2193c6051634b29133280f53f2490d52"
+source = "git+https://github.com/dfinity/ic?rev=7622861bcb3ccbdf52c9ff0bf692516fb1957072#7622861bcb3ccbdf52c9ff0bf692516fb1957072"
 dependencies = [
  "base64 0.13.1",
  "candid",
@@ -3441,7 +3486,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-root"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5fe907da2193c6051634b29133280f53f2490d52#5fe907da2193c6051634b29133280f53f2490d52"
+source = "git+https://github.com/dfinity/ic?rev=7622861bcb3ccbdf52c9ff0bf692516fb1957072#7622861bcb3ccbdf52c9ff0bf692516fb1957072"
 dependencies = [
  "async-trait",
  "build-info",
@@ -3470,7 +3515,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-swap"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5fe907da2193c6051634b29133280f53f2490d52#5fe907da2193c6051634b29133280f53f2490d52"
+source = "git+https://github.com/dfinity/ic?rev=7622861bcb3ccbdf52c9ff0bf692516fb1957072#7622861bcb3ccbdf52c9ff0bf692516fb1957072"
 dependencies = [
  "async-trait",
  "build-info",
@@ -3499,13 +3544,14 @@ dependencies = [
  "maplit",
  "prost",
  "rust_decimal",
+ "rust_decimal_macros",
  "serde",
 ]
 
 [[package]]
 name = "ic-sns-swap-proto-library"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=5fe907da2193c6051634b29133280f53f2490d52#5fe907da2193c6051634b29133280f53f2490d52"
+source = "git+https://github.com/dfinity/ic?rev=7622861bcb3ccbdf52c9ff0bf692516fb1957072#7622861bcb3ccbdf52c9ff0bf692516fb1957072"
 dependencies = [
  "candid",
  "comparable",
@@ -3518,7 +3564,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-wasm"
 version = "1.0.0"
-source = "git+https://github.com/dfinity/ic?rev=5fe907da2193c6051634b29133280f53f2490d52#5fe907da2193c6051634b29133280f53f2490d52"
+source = "git+https://github.com/dfinity/ic?rev=7622861bcb3ccbdf52c9ff0bf692516fb1957072#7622861bcb3ccbdf52c9ff0bf692516fb1957072"
 dependencies = [
  "async-trait",
  "candid",
@@ -3551,9 +3597,9 @@ dependencies = [
 
 [[package]]
 name = "ic-stable-structures"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "774d7d26420c095f2b5f0f71f7b2ff4a5b58b87e0959dccc78b3d513a7db5112"
+checksum = "a314297eb9edb4bbcc2e04d2e634e38d5900b68eadae661e927946d1aba3f9f7"
 dependencies = [
  "ic_principal",
 ]
@@ -3578,7 +3624,7 @@ dependencies = [
 [[package]]
 name = "ic-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5fe907da2193c6051634b29133280f53f2490d52#5fe907da2193c6051634b29133280f53f2490d52"
+source = "git+https://github.com/dfinity/ic?rev=7622861bcb3ccbdf52c9ff0bf692516fb1957072#7622861bcb3ccbdf52c9ff0bf692516fb1957072"
 dependencies = [
  "base64 0.13.1",
  "bincode",
@@ -3605,8 +3651,8 @@ dependencies = [
  "serde_cbor",
  "serde_json",
  "serde_with",
- "strum 0.25.0",
- "strum_macros 0.25.3",
+ "strum 0.26.2",
+ "strum_macros 0.26.2",
  "thiserror",
  "thousands",
 ]
@@ -3614,7 +3660,7 @@ dependencies = [
 [[package]]
 name = "ic-utils"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5fe907da2193c6051634b29133280f53f2490d52#5fe907da2193c6051634b29133280f53f2490d52"
+source = "git+https://github.com/dfinity/ic?rev=7622861bcb3ccbdf52c9ff0bf692516fb1957072#7622861bcb3ccbdf52c9ff0bf692516fb1957072"
 dependencies = [
  "hex",
  "prost",
@@ -3687,7 +3733,7 @@ dependencies = [
  "ff 0.12.1",
  "group 0.12.1",
  "pairing",
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
  "zeroize",
 ]
@@ -3708,7 +3754,7 @@ dependencies = [
 [[package]]
 name = "icp-ledger"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5fe907da2193c6051634b29133280f53f2490d52#5fe907da2193c6051634b29133280f53f2490d52"
+source = "git+https://github.com/dfinity/ic?rev=7622861bcb3ccbdf52c9ff0bf692516fb1957072#7622861bcb3ccbdf52c9ff0bf692516fb1957072"
 dependencies = [
  "candid",
  "comparable",
@@ -3731,14 +3777,14 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_cbor",
- "strum 0.25.0",
- "strum_macros 0.25.3",
+ "strum 0.26.2",
+ "strum_macros 0.26.2",
 ]
 
 [[package]]
 name = "icrc-ledger-client"
 version = "0.1.2"
-source = "git+https://github.com/dfinity/ic?rev=5fe907da2193c6051634b29133280f53f2490d52#5fe907da2193c6051634b29133280f53f2490d52"
+source = "git+https://github.com/dfinity/ic?rev=7622861bcb3ccbdf52c9ff0bf692516fb1957072#7622861bcb3ccbdf52c9ff0bf692516fb1957072"
 dependencies = [
  "async-trait",
  "candid",
@@ -3749,7 +3795,7 @@ dependencies = [
 [[package]]
 name = "icrc-ledger-types"
 version = "0.1.5"
-source = "git+https://github.com/dfinity/ic?rev=5fe907da2193c6051634b29133280f53f2490d52#5fe907da2193c6051634b29133280f53f2490d52"
+source = "git+https://github.com/dfinity/ic?rev=7622861bcb3ccbdf52c9ff0bf692516fb1957072#7622861bcb3ccbdf52c9ff0bf692516fb1957072"
 dependencies = [
  "base32",
  "candid",
@@ -3790,9 +3836,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.2.3"
+version = "2.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "233cf39063f058ea2caae4091bf4a3ef70a653afbc026f5c4a4135d114e3c177"
+checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.3",
@@ -3822,7 +3868,7 @@ version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
 dependencies = [
- "hermit-abi 0.3.6",
+ "hermit-abi 0.3.9",
  "libc",
  "windows-sys 0.48.0",
 ]
@@ -3839,7 +3885,7 @@ version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f23ff5ef2b80d608d61efee834934d862cd92461afc0560dedf493e4c033738b"
 dependencies = [
- "hermit-abi 0.3.6",
+ "hermit-abi 0.3.9",
  "libc",
  "windows-sys 0.52.0",
 ]
@@ -3883,15 +3929,15 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
+checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "js-sys"
-version = "0.3.68"
+version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "406cda4b368d531c842222cf9d2600a9a4acce8d29423695379c6868a143a9ee"
+checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -4009,7 +4055,7 @@ version = "0.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85c833ca1e66078851dba29046874e38f08b2c883700aa29a03ddd3b23814ee8"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.5.0",
  "libc",
  "redox_syscall",
 ]
@@ -4048,9 +4094,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.20"
+version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
+checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 
 [[package]]
 name = "lzma-sys"
@@ -4071,9 +4117,9 @@ checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
 name = "memchr"
-version = "2.7.1"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
+checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
 
 [[package]]
 name = "memoffset"
@@ -4082,6 +4128,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "merlin"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58c38e2799fc0978b65dfff8023ec7843e2330bb462f19198840b34b6582397d"
+dependencies = [
+ "byteorder",
+ "keccak",
+ "rand_core",
+ "zeroize",
 ]
 
 [[package]]
@@ -4107,12 +4165,12 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f3d0b296e374a4e6f3c7b0a1f5a51d748a0d34c85e7dc48fc3fa9a87657fe09"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
 dependencies = [
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
  "windows-sys 0.48.0",
 ]
 
@@ -4197,7 +4255,7 @@ dependencies = [
  "anyhow",
  "backoff",
  "candid",
- "clap 4.5.1",
+ "clap 4.5.4",
  "crc32fast",
  "dfx-core",
  "dfx-extensions-utils",
@@ -4205,6 +4263,7 @@ dependencies = [
  "futures-util",
  "hex",
  "ic-agent",
+ "ic-sns-cli",
  "ic-utils 0.33.0",
  "reqwest",
  "rust_decimal",
@@ -4339,6 +4398,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -4347,7 +4407,7 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi 0.3.6",
+ "hermit-abi 0.3.9",
  "libc",
 ]
 
@@ -4372,7 +4432,7 @@ dependencies = [
 [[package]]
 name = "on_wire"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5fe907da2193c6051634b29133280f53f2490d52#5fe907da2193c6051634b29133280f53f2490d52"
+source = "git+https://github.com/dfinity/ic?rev=7622861bcb3ccbdf52c9ff0bf692516fb1957072#7622861bcb3ccbdf52c9ff0bf692516fb1957072"
 
 [[package]]
 name = "once_cell"
@@ -4382,9 +4442,9 @@ checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "opaque-debug"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openssl"
@@ -4392,7 +4452,7 @@ version = "0.10.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95a0481286a310808298130d22dd1fef0fa571e05a8f44ec801801e84b216b1f"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.5.0",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -4409,7 +4469,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -4429,9 +4489,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.100"
+version = "0.9.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae94056a791d0e1217d18b6cbdccb02c61e3054fc69893607f4067e3bb0b1fd1"
+checksum = "dda2b0f344e78efc2facf7d195d098df0dd72151b26ab98da807afc26c198dff"
 dependencies = [
  "cc",
  "libc",
@@ -4503,7 +4563,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7676374caaee8a325c9e7a2ae557f216c5563a171d6997b0ef8a65af35147700"
 dependencies = [
  "base64ct",
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
 ]
 
@@ -4567,9 +4627,9 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pest"
-version = "2.7.7"
+version = "2.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "219c0dcc30b6a27553f9cc242972b67f75b60eb0db71f0b5462f38b058c41546"
+checksum = "56f8023d0fb78c8e03784ea1c7f3fa36e68a723138990b8d5a47d916b651e7a8"
 dependencies = [
  "memchr",
  "thiserror",
@@ -4578,9 +4638,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.7.7"
+version = "2.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22e1288dbd7786462961e69bfd4df7848c1e37e8b74303dbdab82c3a9cdd2809"
+checksum = "b0d24f72393fd16ab6ac5738bc33cdb6a9aa73f8b902e8fe29cf4e67d7dd1026"
 dependencies = [
  "pest",
  "pest_generator",
@@ -4588,22 +4648,22 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.7.7"
+version = "2.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1381c29a877c6d34b8c176e734f35d7f7f5b3adaefe940cb4d1bb7af94678e2e"
+checksum = "fdc17e2a6c7d0a492f0158d7a4bd66cc17280308bbaff78d5bef566dca35ab80"
 dependencies = [
  "pest",
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.55",
 ]
 
 [[package]]
 name = "pest_meta"
-version = "2.7.7"
+version = "2.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0934d6907f148c22a3acbda520c7eed243ad7487a30f51f6ce52b58b7077a8a"
+checksum = "934cd7631c050f4674352a6e835d5f6711ffbfb9345c2fc0107155ac495ae293"
 dependencies = [
  "once_cell",
  "pest",
@@ -4617,13 +4677,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9"
 dependencies = [
  "fixedbitset",
- "indexmap 2.2.3",
+ "indexmap 2.2.6",
 ]
 
 [[package]]
 name = "phantom_newtype"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5fe907da2193c6051634b29133280f53f2490d52#5fe907da2193c6051634b29133280f53f2490d52"
+source = "git+https://github.com/dfinity/ic?rev=7622861bcb3ccbdf52c9ff0bf692516fb1957072#7622861bcb3ccbdf52c9ff0bf692516fb1957072"
 dependencies = [
  "candid",
  "serde",
@@ -4679,6 +4739,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 
 [[package]]
+name = "platforms"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db23d408679286588f4d4644f965003d056e3dd5abcaaa938116871d7ce2fee7"
+
+[[package]]
 name = "polling"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4696,9 +4762,9 @@ dependencies = [
 
 [[package]]
 name = "polyval"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52cff9d1d4dee5fe6d03729099f4a310a41179e0a10dbf542039873f2e826fb"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -4771,12 +4837,12 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a41cf62165e97c7f814d2221421dbb9afcbcdb0a88068e5ea206e19951c2cbb5"
+checksum = "8d3928fb5db768cb86f891ff014f0144589297e3c6a1aba6ed7cecfdace270c7"
 dependencies = [
  "proc-macro2",
- "syn 2.0.50",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -4858,9 +4924,9 @@ checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.78"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
+checksum = "e835ff2298f5721608eb1a980ecaee1aef2c132bf95ecc026a11b7bf3c01c02e"
 dependencies = [
  "unicode-ident",
 ]
@@ -4882,7 +4948,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c55e02e35260070b6f716a2423c2ff1c3bb1642ddca6f99e1f26d06268a0e2d2"
 dependencies = [
  "bytes",
- "heck",
+ "heck 0.4.1",
  "itertools 0.11.0",
  "log",
  "multimap",
@@ -4892,7 +4958,7 @@ dependencies = [
  "prost",
  "prost-types",
  "regex",
- "syn 2.0.50",
+ "syn 2.0.55",
  "tempfile",
  "which",
 ]
@@ -4907,7 +4973,7 @@ dependencies = [
  "itertools 0.11.0",
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -4971,7 +5037,7 @@ checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
  "rand_chacha",
- "rand_core 0.6.4",
+ "rand_core",
 ]
 
 [[package]]
@@ -4981,16 +5047,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
-dependencies = [
- "getrandom 0.1.16",
+ "rand_core",
 ]
 
 [[package]]
@@ -4999,14 +5056,14 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.12",
+ "getrandom",
 ]
 
 [[package]]
 name = "rangemap"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "795915a3930a5d6bafd9053d37602fea3e61be2e5d4d788983a8ba9654c1c6f2"
+checksum = "f60fcc7d6849342eff22c4350c8b9a989ee8ceabc4b481253e8946b9fe83d684"
 
 [[package]]
 name = "redox_syscall"
@@ -5023,16 +5080,16 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a18479200779601e498ada4e8c1e1f50e3ee19deb0259c25825a98b5603b2cb4"
 dependencies = [
- "getrandom 0.2.12",
+ "getrandom",
  "libredox",
  "thiserror",
 ]
 
 [[package]]
 name = "regex"
-version = "1.10.3"
+version = "1.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15"
+checksum = "c117dbdfde9c8308975b6a18d71f3f385c89461f7b3fb054288ecf2a2058ba4c"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -5042,9 +5099,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bb987efffd3c6d0d8f5f89510bb458559eab11e4f869acb20bf845e016259cd"
+checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -5053,14 +5110,14 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
+checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
 
 [[package]]
 name = "registry-canister"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5fe907da2193c6051634b29133280f53f2490d52#5fe907da2193c6051634b29133280f53f2490d52"
+source = "git+https://github.com/dfinity/ic?rev=7622861bcb3ccbdf52c9ff0bf692516fb1957072#7622861bcb3ccbdf52c9ff0bf692516fb1957072"
 dependencies = [
  "build-info",
  "build-info-build",
@@ -5110,9 +5167,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.24"
+version = "0.11.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6920094eb85afde5e4a138be3f2de8bbdf28000f0029e72c45025a56b042251"
+checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
 dependencies = [
  "base64 0.21.7",
  "bytes",
@@ -5198,7 +5255,7 @@ checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom 0.2.12",
+ "getrandom",
  "libc",
  "spin 0.9.8",
  "untrusted 0.9.0",
@@ -5245,9 +5302,9 @@ dependencies = [
 
 [[package]]
 name = "rust_decimal"
-version = "1.34.3"
+version = "1.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39449a79f45e8da28c57c341891b69a183044b29518bb8f86dbac9df60bb7df"
+checksum = "1790d1c4c0ca81211399e0e0af16333276f375209e71a37b67698a373db5b47a"
 dependencies = [
  "arrayvec 0.7.4",
  "borsh",
@@ -5315,11 +5372,11 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.31"
+version = "0.38.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea3e1a662af26cd7a3ba09c0297a31af215563ecf42817c98df621387f4e949"
+checksum = "65e04861e65f21776e67888bfbea442b3642beaa0138fdb1dd7a84a52dffdb89"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.5.0",
  "errno",
  "libc",
  "linux-raw-sys 0.4.13",
@@ -5564,7 +5621,7 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bef2ebfde456fb76bbcf9f59315333decc4fda0b2b44b420243c11e0f5ec1f5"
 dependencies = [
- "half 1.8.2",
+ "half 1.8.3",
  "serde",
 ]
 
@@ -5576,7 +5633,7 @@ checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -5592,9 +5649,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.114"
+version = "1.0.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5f09b1bd632ef549eaa9f60a1f8de742bdbc698e6cee2095fc84dde5f549ae0"
+checksum = "12dc5c46daa8e9fdf4f5e71b6cf9a53f2487da0e86e55808e2d35539666497dd"
 dependencies = [
  "itoa",
  "ryu",
@@ -5609,7 +5666,7 @@ checksum = "0b2e6b945e9d3df726b65d6ee24060aff8e3533d431f677a9695db04eff9dfdb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -5659,11 +5716,11 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.9.32"
+version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd075d994154d4a774f95b51fb96bdc2832b0ea48425c92546073816cda1f2f"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.2.3",
+ "indexmap 2.2.6",
  "itoa",
  "ryu",
  "serde",
@@ -5717,7 +5774,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
 dependencies = [
  "digest 0.10.7",
- "rand_core 0.6.4",
+ "rand_core",
 ]
 
 [[package]]
@@ -5727,7 +5784,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest 0.10.7",
- "rand_core 0.6.4",
+ "rand_core",
 ]
 
 [[package]]
@@ -5802,9 +5859,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.13.1"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
+checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "sns"
@@ -5812,7 +5869,7 @@ version = "0.3.1"
 dependencies = [
  "anyhow",
  "candid",
- "clap 4.5.1",
+ "clap 4.5.4",
  "dfx-core",
  "dfx-extensions-utils",
  "fn-error-context",
@@ -5834,12 +5891,12 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.5.5"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b5fac59a5cb5dd637972e5fca70daf0523c9067fcdc4842f053dae04a18f8e9"
+checksum = "05ffd9c0a93b7543e062e759284fcf5f5e3b098501104bfbdde4d404db792871"
 dependencies = [
  "libc",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5913,11 +5970,11 @@ checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
 
 [[package]]
 name = "strum"
-version = "0.25.0"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
+checksum = "5d8cec3501a5194c432b2b7976db6b7d10ec95c253208b45f83f7136aa985e29"
 dependencies = [
- "strum_macros 0.25.3",
+ "strum_macros 0.26.2",
 ]
 
 [[package]]
@@ -5926,7 +5983,7 @@ version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "rustversion",
@@ -5935,15 +5992,15 @@ dependencies = [
 
 [[package]]
 name = "strum_macros"
-version = "0.25.3"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
+checksum = "c6cf59daf282c0a494ba14fd21610a0325f9f90ec9d1231dea26bcb1d696c946"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.50",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -5971,9 +6028,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.50"
+version = "2.0.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74f1bdc9872430ce9b75da68329d1c1746faf50ffac5f19e02b71e37ff881ffb"
+checksum = "002a1b3dbf967edfafc32655d0f377ab0bb7b994aa1d32c8cc7e9b8bf3ebb8f0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5989,7 +6046,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -6056,13 +6113,13 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.10.0"
+version = "3.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a365e8cd18e44762ef95d87f284f4b5cd04107fec2ff3052bd6a3e6069669e67"
+checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
 dependencies = [
  "cfg-if",
- "fastrand 2.0.1",
- "rustix 0.38.31",
+ "fastrand 2.0.2",
+ "rustix 0.38.32",
  "windows-sys 0.52.0",
 ]
 
@@ -6100,22 +6157,22 @@ checksum = "23d434d3f8967a09480fb04132ebe0a3e088c173e6d0ee7897abbdf4eab0f8b9"
 
 [[package]]
 name = "thiserror"
-version = "1.0.57"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e45bcbe8ed29775f228095caf2cd67af7a4ccf756ebff23a306bf3e8b47b24b"
+checksum = "03468839009160513471e86a034bb2c5c0e4baae3b43f79ffc55c4a5427b3297"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.57"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a953cb265bef375dae3de6663da4d3804eee9682ea80d8e2542529b73c531c81"
+checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -6201,9 +6258,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.36.0"
+version = "1.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61285f6515fa018fb2d1e46eb21223fff441ee8db5d0f1435e8ab4f5cdb80931"
+checksum = "1adbebffeca75fcfd058afa480fb6c0b81e165a0323f9c9d39c9697e37c46787"
 dependencies = [
  "backtrace",
  "bytes",
@@ -6211,7 +6268,7 @@ dependencies = [
  "mio",
  "num_cpus",
  "pin-project-lite",
- "socket2 0.5.5",
+ "socket2 0.5.6",
  "windows-sys 0.48.0",
 ]
 
@@ -6281,7 +6338,7 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.2.3",
+ "indexmap 2.2.6",
  "toml_datetime",
  "winnow",
 ]
@@ -6292,7 +6349,7 @@ version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
 dependencies = [
- "indexmap 2.2.3",
+ "indexmap 2.2.6",
  "toml_datetime",
  "winnow",
 ]
@@ -6406,9 +6463,9 @@ dependencies = [
 
 [[package]]
 name = "unsafe-libyaml"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab4c90930b95a82d00dc9e9ac071b4991924390d46cbd0dfe566148667605e4b"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"
@@ -6447,9 +6504,9 @@ checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "uuid"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f00cc9702ca12d3c81455259621e676d0f7251cec66a21e98fe2e9a37db93b2a"
+checksum = "a183cf7feeba97b4dd1c0d46788634f6221d87fa961b305bed08c851829efcc0"
 
 [[package]]
 name = "vcpkg"
@@ -6480,21 +6537,15 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.9.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
-
-[[package]]
-name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1e124130aee3fb58c5bdd6b639a0509486b0338acaaae0c84a5124b0f588b7f"
+checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -6502,24 +6553,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9e7e1900c352b609c8488ad12639a311045f40a35491fb69ba8c12f758af70b"
+checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.55",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.41"
+version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877b9c3f61ceea0e56331985743b13f3d25c406a7098d45180fb5f09bc19ed97"
+checksum = "76bc14366121efc8dbb487ab05bcc9d346b3b5ec0eaa76e46594cabbe51762c0"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -6529,9 +6580,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b30af9e2d358182b5c7449424f017eba305ed32a7010509ede96cdc4696c46ed"
+checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -6539,22 +6590,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "642f325be6301eb8107a83d12a8ac6c1e1c54345a7ef1a9261962dfefda09e66"
+checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.55",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f186bd2dcf04330886ce82d6f33dd75a7bfcf69ecf5763b89fcde53b6ac9838"
+checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
 
 [[package]]
 name = "wasm-streams"
@@ -6571,9 +6622,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.68"
+version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96565907687f7aceb35bc5fc03770a8a0471d82e479f25832f54a0e3f4b28446"
+checksum = "77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -6613,7 +6664,7 @@ dependencies = [
  "either",
  "home",
  "once_cell",
- "rustix 0.38.31",
+ "rustix 0.38.32",
 ]
 
 [[package]]
@@ -6653,7 +6704,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
- "windows-targets 0.52.0",
+ "windows-targets 0.52.4",
 ]
 
 [[package]]
@@ -6671,7 +6722,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.0",
+ "windows-targets 0.52.4",
 ]
 
 [[package]]
@@ -6691,17 +6742,17 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd"
+checksum = "7dd37b7e5ab9018759f893a1952c9420d060016fc19a472b4bb20d1bdd694d1b"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.0",
- "windows_aarch64_msvc 0.52.0",
- "windows_i686_gnu 0.52.0",
- "windows_i686_msvc 0.52.0",
- "windows_x86_64_gnu 0.52.0",
- "windows_x86_64_gnullvm 0.52.0",
- "windows_x86_64_msvc 0.52.0",
+ "windows_aarch64_gnullvm 0.52.4",
+ "windows_aarch64_msvc 0.52.4",
+ "windows_i686_gnu 0.52.4",
+ "windows_i686_msvc 0.52.4",
+ "windows_x86_64_gnu 0.52.4",
+ "windows_x86_64_gnullvm 0.52.4",
+ "windows_x86_64_msvc 0.52.4",
 ]
 
 [[package]]
@@ -6712,9 +6763,9 @@ checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
+checksum = "bcf46cf4c365c6f2d1cc93ce535f2c8b244591df96ceee75d8e83deb70a9cac9"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -6724,9 +6775,9 @@ checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
+checksum = "da9f259dd3bcf6990b55bffd094c4f7235817ba4ceebde8e6d11cd0c5633b675"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -6736,9 +6787,9 @@ checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
+checksum = "b474d8268f99e0995f25b9f095bc7434632601028cf86590aea5c8a5cb7801d3"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -6748,9 +6799,9 @@ checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
+checksum = "1515e9a29e5bed743cb4415a9ecf5dfca648ce85ee42e15873c3cd8610ff8e02"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -6760,9 +6811,9 @@ checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
+checksum = "5eee091590e89cc02ad514ffe3ead9eb6b660aedca2183455434b93546371a03"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -6772,9 +6823,9 @@ checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
+checksum = "77ca79f2451b49fa9e2af39f0747fe999fcda4f5e241b2898624dca97a1f2177"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -6784,9 +6835,9 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.0"
+version = "0.52.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
+checksum = "32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8"
 
 [[package]]
 name = "winnow"
@@ -6818,12 +6869,11 @@ dependencies = [
 
 [[package]]
 name = "x509-parser"
-version = "0.14.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0ecbeb7b67ce215e40e3cc7f2ff902f94a223acf44995934763467e7b1febc8"
+checksum = "7069fba5b66b9193bd2c5d3d4ff12b839118f6bcbef5328efafafb5395cf63da"
 dependencies = [
  "asn1-rs",
- "base64 0.13.1",
  "data-encoding",
  "der-parser",
  "lazy_static",
@@ -6842,7 +6892,7 @@ checksum = "8da84f1a25939b27f6820d92aed108f83ff920fdf11a7b19366c27c4cda81d4f"
 dependencies = [
  "libc",
  "linux-raw-sys 0.4.13",
- "rustix 0.38.31",
+ "rustix 0.38.32",
 ]
 
 [[package]]
@@ -6912,7 +6962,7 @@ checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.55",
 ]
 
 [[package]]
@@ -6932,7 +6982,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.50",
+ "syn 2.0.55",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ dfx-core = { git = "https://github.com/dfinity/sdk", rev = "9fd111de914cf43af05a
 dfx-extensions-utils.path = "./extensions-utils"
 
 anyhow = "^1"
-candid = "^0.10.2"
+candid = "0.10"
 clap = { version = "4.2.1", features = ["derive", "env"] }
 flate2 = { version = "1.0.25", default-features = false, features = [
     "zlib-ng",
@@ -32,9 +32,9 @@ reqwest = { version = "^0.11.22", default-features = false, features = [
 serde = "^1.0"
 slog = "^2.7.0"
 tempfile = "3.5.0"
-tokio = "^1.36.0"
+tokio = { version = "^1.36.0", features = ["rt-multi-thread"] }
 url = "^2.4.1"
-ic-sns-cli = { git = "https://github.com/dfinity/ic", rev = "5fe907da2193c6051634b29133280f53f2490d52" }
+ic-sns-cli = { git = "https://github.com/dfinity/ic", rev = "7622861bcb3ccbdf52c9ff0bf692516fb1957072" }
 
 # Config for 'cargo dist'
 [workspace.metadata.dist]

--- a/extensions/nns/Cargo.toml
+++ b/extensions/nns/Cargo.toml
@@ -17,6 +17,7 @@ dfx-extensions-utils.workspace = true
 ic-agent.workspace = true
 ic-utils.workspace = true
 candid.workspace = true
+ic-sns-cli.workspace = true
 
 anyhow.workspace = true
 backoff = "0.4.0"
@@ -38,4 +39,4 @@ tokio.workspace = true
 # list of replacements to be made after issuing `cargo release -p nns SEMVER`
 
 [package.metadata.dist]
-include = ["extension.json", "sns-cli", "ic-admin", "ic-nns-init"]
+include = ["extension.json", "ic-admin", "ic-nns-init"]

--- a/extensions/nns/src/install_nns.rs
+++ b/extensions/nns/src/install_nns.rs
@@ -16,6 +16,7 @@ use dfx_extensions_utils::{
     SnsCanisterInstallation, StandardCanister, ED25519_TEST_ACCOUNT, NNS_CORE, NNS_FRONTEND,
     NNS_SNS_WASM, SECP256K1_TEST_ACCOUNT, SNS_CANISTERS,
 };
+use ic_sns_cli::{add_sns_wasm_for_tests, AddSnsWasmForTestsArgs};
 
 use anyhow::{anyhow, bail, Context};
 use backoff::backoff::Backoff;
@@ -546,20 +547,12 @@ pub fn upload_nns_sns_wasms_canister_wasms(dfx_cache_path: &Path) -> anyhow::Res
     } in SNS_CANISTERS
     {
         let wasm_path = nns_wasm_dir(dfx_cache_path).join(wasm_name);
-        let args = vec![
-            "add-sns-wasm-for-tests".into(),
-            "--network".into(),
-            "local".into(),
-            "--override-sns-wasm-canister-id-for-tests".into(),
-            NNS_SNS_WASM.canister_id.into(),
-            "--wasm-file".into(),
-            wasm_path.clone().into_os_string(),
-            upload_name.into(),
-        ];
-        call_extension_bundled_binary("sns-cli", &args, dfx_cache_path)
-            .map_err(|e| anyhow!(
-                        "Failed to upload {upload_name} from {wasm_path:?} to the nns-sns-wasm canister by calling `sns-cli`: {e}"
-                    ))?;
+        add_sns_wasm_for_tests(AddSnsWasmForTestsArgs {
+            wasm_file: wasm_path.clone(),
+            canister_type: upload_name.to_string(),
+            override_sns_wasm_canister_id_for_tests: Some(NNS_SNS_WASM.canister_id.into()),
+            network: "local".to_string(),
+        });
     }
     Ok(())
 }


### PR DESCRIPTION
This is a follow up to #91 which did the same thing for the sns extension.