### PR TITLE
fix: allow version numbers to diverge

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,6 @@ on:
   push:
     tags:
       - '**[0-9]+.[0-9]+.[0-9]+*'
-  pull_request:
 
 jobs:
   # Run 'cargo dist plan' (or host) to determine what tasks we need to do

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ cargo-dist-version = "0.10.0"
 # The installers to generate for each app
 installers = []
 # Publish jobs to run in CI
-pr-run-mode = "plan"
+pr-run-mode = "skip"
 
 
 # The profile that 'cargo dist' will build with


### PR DESCRIPTION
In "plan" pr-run-mode, cargo-dist doesn't have a pr-run-mode that can handle different projects in a repo that have different version numbers.  See https://github.com/axodotdev/cargo-dist/issues/905

This means that a PR that updates the version of only one extension or updates to distinct versions will always fail CI.  The workflow prior to https://github.com/dfinity/dfx-extensions/pull/85 also skipped this step for PRs, though this was done by hand-editing the .yml file, rather than through settings in Cargo.toml, so it wasn't obvious.