### PR TITLE
Add support for the "neuron-id-to-candid-subaccount" command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -203,9 +203,9 @@ checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 
 [[package]]
 name = "asn1-rs"
-version = "0.5.2"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f6fd5ddaf0351dff5b8da21b2fb4ff8e08ddd02857f0bf69c47639106c0fff0"
+checksum = "22ad1373757efa0f70ec53939aabc7152e1591cb485208052993070ac8d2429d"
 dependencies = [
  "asn1-rs-derive",
  "asn1-rs-impl",
@@ -219,25 +219,25 @@ dependencies = [
 
 [[package]]
 name = "asn1-rs-derive"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "726535892e8eae7e70657b4c8ea93d26b8553afb1ce617caee529ef96d7dee6c"
+checksum = "7378575ff571966e99a744addeff0bff98b8ada0dedf1956d59e634db95eaac1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.66",
  "synstructure",
 ]
 
 [[package]]
 name = "asn1-rs-impl"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2777730b2039ac0f95f093556e61b6d26cebed5393ca6f152717777cec3a42ed"
+checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -1190,7 +1190,7 @@ dependencies = [
 [[package]]
 name = "cycles-minting-canister"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f79476803e097d9fd5f7e67d45f6818348b51ac9#f79476803e097d9fd5f7e67d45f6818348b51ac9"
+source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
 dependencies = [
  "async-trait",
  "base64 0.13.1",
@@ -1299,9 +1299,9 @@ dependencies = [
 
 [[package]]
 name = "der-parser"
-version = "8.2.0"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbd676fbbab537128ef0278adb5576cf363cff6aa22a7b24effe97347cfab61e"
+checksum = "5cd0a5c643689626bec213c4d8bd4d96acc8ffdb4ad4bb6bc16abf27d5f4b553"
 dependencies = [
  "asn1-rs",
  "displaydoc",
@@ -1347,7 +1347,7 @@ dependencies = [
 [[package]]
 name = "dfn_candid"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f79476803e097d9fd5f7e67d45f6818348b51ac9#f79476803e097d9fd5f7e67d45f6818348b51ac9"
+source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
 dependencies = [
  "candid",
  "dfn_core",
@@ -1359,7 +1359,7 @@ dependencies = [
 [[package]]
 name = "dfn_core"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f79476803e097d9fd5f7e67d45f6818348b51ac9#f79476803e097d9fd5f7e67d45f6818348b51ac9"
+source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
 dependencies = [
  "ic-base-types",
  "on_wire",
@@ -1368,7 +1368,7 @@ dependencies = [
 [[package]]
 name = "dfn_http"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f79476803e097d9fd5f7e67d45f6818348b51ac9#f79476803e097d9fd5f7e67d45f6818348b51ac9"
+source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
 dependencies = [
  "candid",
  "dfn_candid",
@@ -1380,7 +1380,7 @@ dependencies = [
 [[package]]
 name = "dfn_http_metrics"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f79476803e097d9fd5f7e67d45f6818348b51ac9#f79476803e097d9fd5f7e67d45f6818348b51ac9"
+source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
 dependencies = [
  "dfn_candid",
  "dfn_core",
@@ -1392,7 +1392,7 @@ dependencies = [
 [[package]]
 name = "dfn_protobuf"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f79476803e097d9fd5f7e67d45f6818348b51ac9#f79476803e097d9fd5f7e67d45f6818348b51ac9"
+source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
 dependencies = [
  "on_wire",
  "prost",
@@ -1798,7 +1798,7 @@ checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
 [[package]]
 name = "fe-derive"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f79476803e097d9fd5f7e67d45f6818348b51ac9#f79476803e097d9fd5f7e67d45f6818348b51ac9"
+source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
 dependencies = [
  "hex",
  "num-bigint-dig",
@@ -2536,7 +2536,7 @@ dependencies = [
 [[package]]
 name = "ic-base-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f79476803e097d9fd5f7e67d45f6818348b51ac9#f79476803e097d9fd5f7e67d45f6818348b51ac9"
+source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
 dependencies = [
  "byte-unit",
  "bytes",
@@ -2552,7 +2552,8 @@ dependencies = [
 [[package]]
 name = "ic-btc-interface"
 version = "0.2.0"
-source = "git+https://github.com/dfinity/bitcoin-canister?rev=62a71e47c491fb842ccc257b1c675651501f4b82#62a71e47c491fb842ccc257b1c675651501f4b82"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46c2d1eedb5fcd02b6aab21fa6e0989ae560505e510bf221af9ab57bffbc83ac"
 dependencies = [
  "candid",
  "serde",
@@ -2562,7 +2563,7 @@ dependencies = [
 [[package]]
 name = "ic-btc-types-internal"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f79476803e097d9fd5f7e67d45f6818348b51ac9#f79476803e097d9fd5f7e67d45f6818348b51ac9"
+source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
 dependencies = [
  "candid",
  "ic-btc-interface",
@@ -2575,7 +2576,7 @@ dependencies = [
 [[package]]
 name = "ic-canister-client-sender"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f79476803e097d9fd5f7e67d45f6818348b51ac9#f79476803e097d9fd5f7e67d45f6818348b51ac9"
+source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
 dependencies = [
  "ic-base-types",
  "ic-crypto-ecdsa-secp256k1",
@@ -2588,7 +2589,7 @@ dependencies = [
 [[package]]
 name = "ic-canister-log"
 version = "0.2.0"
-source = "git+https://github.com/dfinity/ic?rev=f79476803e097d9fd5f7e67d45f6818348b51ac9#f79476803e097d9fd5f7e67d45f6818348b51ac9"
+source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
 dependencies = [
  "serde",
 ]
@@ -2596,7 +2597,7 @@ dependencies = [
 [[package]]
 name = "ic-canister-profiler"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f79476803e097d9fd5f7e67d45f6818348b51ac9#f79476803e097d9fd5f7e67d45f6818348b51ac9"
+source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
 dependencies = [
  "ic-metrics-encoder",
  "ic0 0.18.11",
@@ -2605,7 +2606,7 @@ dependencies = [
 [[package]]
 name = "ic-canisters-http-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f79476803e097d9fd5f7e67d45f6818348b51ac9#f79476803e097d9fd5f7e67d45f6818348b51ac9"
+source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
 dependencies = [
  "candid",
  "serde",
@@ -2693,12 +2694,12 @@ dependencies = [
 [[package]]
 name = "ic-constants"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f79476803e097d9fd5f7e67d45f6818348b51ac9#f79476803e097d9fd5f7e67d45f6818348b51ac9"
+source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
 
 [[package]]
 name = "ic-crypto-ecdsa-secp256k1"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f79476803e097d9fd5f7e67d45f6818348b51ac9#f79476803e097d9fd5f7e67d45f6818348b51ac9"
+source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
 dependencies = [
  "k256 0.13.3",
  "lazy_static",
@@ -2712,7 +2713,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-ed25519"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f79476803e097d9fd5f7e67d45f6818348b51ac9#f79476803e097d9fd5f7e67d45f6818348b51ac9"
+source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
 dependencies = [
  "curve25519-dalek",
  "ed25519-dalek",
@@ -2726,7 +2727,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-getrandom-for-wasm"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f79476803e097d9fd5f7e67d45f6818348b51ac9#f79476803e097d9fd5f7e67d45f6818348b51ac9"
+source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
 dependencies = [
  "getrandom",
 ]
@@ -2734,7 +2735,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-basic-sig-der-utils"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f79476803e097d9fd5f7e67d45f6818348b51ac9#f79476803e097d9fd5f7e67d45f6818348b51ac9"
+source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
 dependencies = [
  "hex",
  "ic-types",
@@ -2744,7 +2745,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-basic-sig-ed25519"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f79476803e097d9fd5f7e67d45f6818348b51ac9#f79476803e097d9fd5f7e67d45f6818348b51ac9"
+source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
 dependencies = [
  "base64 0.13.1",
  "curve25519-dalek",
@@ -2766,7 +2767,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-bls12-381-type"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f79476803e097d9fd5f7e67d45f6818348b51ac9#f79476803e097d9fd5f7e67d45f6818348b51ac9"
+source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
 dependencies = [
  "hex",
  "ic_bls12_381",
@@ -2784,7 +2785,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-hmac"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f79476803e097d9fd5f7e67d45f6818348b51ac9#f79476803e097d9fd5f7e67d45f6818348b51ac9"
+source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
 dependencies = [
  "ic-crypto-internal-sha2",
 ]
@@ -2792,7 +2793,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-multi-sig-bls12381"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f79476803e097d9fd5f7e67d45f6818348b51ac9#f79476803e097d9fd5f7e67d45f6818348b51ac9"
+source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
 dependencies = [
  "base64 0.13.1",
  "hex",
@@ -2811,7 +2812,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-seed"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f79476803e097d9fd5f7e67d45f6818348b51ac9#f79476803e097d9fd5f7e67d45f6818348b51ac9"
+source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
 dependencies = [
  "hex",
  "ic-crypto-sha2",
@@ -2824,7 +2825,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-sha2"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f79476803e097d9fd5f7e67d45f6818348b51ac9#f79476803e097d9fd5f7e67d45f6818348b51ac9"
+source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
 dependencies = [
  "sha2 0.10.8",
 ]
@@ -2832,7 +2833,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-threshold-sig-bls12381"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f79476803e097d9fd5f7e67d45f6818348b51ac9#f79476803e097d9fd5f7e67d45f6818348b51ac9"
+source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
 dependencies = [
  "base64 0.13.1",
  "cached 0.49.3",
@@ -2858,7 +2859,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-threshold-sig-ecdsa"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f79476803e097d9fd5f7e67d45f6818348b51ac9#f79476803e097d9fd5f7e67d45f6818348b51ac9"
+source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
 dependencies = [
  "curve25519-dalek",
  "fe-derive",
@@ -2888,7 +2889,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f79476803e097d9fd5f7e67d45f6818348b51ac9#f79476803e097d9fd5f7e67d45f6818348b51ac9"
+source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
 dependencies = [
  "arrayvec 0.7.4",
  "hex",
@@ -2905,7 +2906,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-node-key-validation"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f79476803e097d9fd5f7e67d45f6818348b51ac9#f79476803e097d9fd5f7e67d45f6818348b51ac9"
+source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
 dependencies = [
  "hex",
  "ic-base-types",
@@ -2923,7 +2924,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-secrets-containers"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f79476803e097d9fd5f7e67d45f6818348b51ac9#f79476803e097d9fd5f7e67d45f6818348b51ac9"
+source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
 dependencies = [
  "serde",
  "zeroize",
@@ -2932,7 +2933,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-sha2"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f79476803e097d9fd5f7e67d45f6818348b51ac9#f79476803e097d9fd5f7e67d45f6818348b51ac9"
+source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
 dependencies = [
  "ic-crypto-internal-sha2",
 ]
@@ -2940,7 +2941,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-test-utils-reproducible-rng"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f79476803e097d9fd5f7e67d45f6818348b51ac9#f79476803e097d9fd5f7e67d45f6818348b51ac9"
+source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
 dependencies = [
  "rand",
  "rand_chacha",
@@ -2949,7 +2950,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-tls-cert-validation"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f79476803e097d9fd5f7e67d45f6818348b51ac9#f79476803e097d9fd5f7e67d45f6818348b51ac9"
+source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
 dependencies = [
  "hex",
  "ic-crypto-internal-basic-sig-ed25519",
@@ -2963,7 +2964,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-tree-hash"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f79476803e097d9fd5f7e67d45f6818348b51ac9#f79476803e097d9fd5f7e67d45f6818348b51ac9"
+source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
 dependencies = [
  "assert_matches",
  "ic-crypto-internal-types",
@@ -2977,7 +2978,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-utils-basic-sig"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f79476803e097d9fd5f7e67d45f6818348b51ac9#f79476803e097d9fd5f7e67d45f6818348b51ac9"
+source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
 dependencies = [
  "ic-base-types",
  "ic-crypto-ed25519",
@@ -2987,7 +2988,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-utils-ni-dkg"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=f79476803e097d9fd5f7e67d45f6818348b51ac9#f79476803e097d9fd5f7e67d45f6818348b51ac9"
+source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
 dependencies = [
  "ic-crypto-internal-types",
  "ic-protobuf",
@@ -2997,7 +2998,7 @@ dependencies = [
 [[package]]
 name = "ic-error-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f79476803e097d9fd5f7e67d45f6818348b51ac9#f79476803e097d9fd5f7e67d45f6818348b51ac9"
+source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
 dependencies = [
  "ic-protobuf",
  "ic-utils 0.9.0",
@@ -3009,16 +3010,19 @@ dependencies = [
 [[package]]
 name = "ic-icp-index"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f79476803e097d9fd5f7e67d45f6818348b51ac9#f79476803e097d9fd5f7e67d45f6818348b51ac9"
+source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
 dependencies = [
  "candid",
  "ciborium",
+ "dfn_core",
+ "ic-base-types",
  "ic-canister-log",
  "ic-canisters-http-types",
  "ic-cdk",
  "ic-cdk-macros 0.9.0",
  "ic-cdk-timers",
  "ic-icrc1-index-ng",
+ "ic-ledger-canister-core",
  "ic-ledger-core",
  "ic-metrics-encoder",
  "ic-stable-structures",
@@ -3034,7 +3038,7 @@ dependencies = [
 [[package]]
 name = "ic-icrc1"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f79476803e097d9fd5f7e67d45f6818348b51ac9#f79476803e097d9fd5f7e67d45f6818348b51ac9"
+source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
 dependencies = [
  "candid",
  "ciborium",
@@ -3056,7 +3060,7 @@ dependencies = [
 [[package]]
 name = "ic-icrc1-index-ng"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f79476803e097d9fd5f7e67d45f6818348b51ac9#f79476803e097d9fd5f7e67d45f6818348b51ac9"
+source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
 dependencies = [
  "candid",
  "ciborium",
@@ -3070,6 +3074,7 @@ dependencies = [
  "ic-crypto-sha2",
  "ic-icrc1",
  "ic-icrc1-tokens-u64",
+ "ic-ledger-canister-core",
  "ic-ledger-core",
  "ic-metrics-encoder",
  "ic-stable-structures",
@@ -3083,7 +3088,7 @@ dependencies = [
 [[package]]
 name = "ic-icrc1-ledger"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f79476803e097d9fd5f7e67d45f6818348b51ac9#f79476803e097d9fd5f7e67d45f6818348b51ac9"
+source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
 dependencies = [
  "async-trait",
  "candid",
@@ -3111,7 +3116,7 @@ dependencies = [
 [[package]]
 name = "ic-icrc1-tokens-u64"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=f79476803e097d9fd5f7e67d45f6818348b51ac9#f79476803e097d9fd5f7e67d45f6818348b51ac9"
+source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
 dependencies = [
  "candid",
  "ic-ledger-core",
@@ -3136,7 +3141,7 @@ dependencies = [
 [[package]]
 name = "ic-ledger-canister-core"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f79476803e097d9fd5f7e67d45f6818348b51ac9#f79476803e097d9fd5f7e67d45f6818348b51ac9"
+source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
 dependencies = [
  "async-trait",
  "candid",
@@ -3154,7 +3159,7 @@ dependencies = [
 [[package]]
 name = "ic-ledger-core"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f79476803e097d9fd5f7e67d45f6818348b51ac9#f79476803e097d9fd5f7e67d45f6818348b51ac9"
+source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
 dependencies = [
  "candid",
  "ic-ledger-hash-of",
@@ -3166,7 +3171,7 @@ dependencies = [
 [[package]]
 name = "ic-ledger-hash-of"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=f79476803e097d9fd5f7e67d45f6818348b51ac9#f79476803e097d9fd5f7e67d45f6818348b51ac9"
+source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
 dependencies = [
  "candid",
  "hex",
@@ -3176,7 +3181,7 @@ dependencies = [
 [[package]]
 name = "ic-management-canister-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f79476803e097d9fd5f7e67d45f6818348b51ac9#f79476803e097d9fd5f7e67d45f6818348b51ac9"
+source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
 dependencies = [
  "candid",
  "ic-base-types",
@@ -3201,7 +3206,7 @@ checksum = "8b5c7628eac357aecda461130f8074468be5aa4d258a002032d82d817f79f1f8"
 [[package]]
 name = "ic-nervous-system-clients"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=f79476803e097d9fd5f7e67d45f6818348b51ac9#f79476803e097d9fd5f7e67d45f6818348b51ac9"
+source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
 dependencies = [
  "async-trait",
  "candid",
@@ -3224,12 +3229,12 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-collections-union-multi-map"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=f79476803e097d9fd5f7e67d45f6818348b51ac9#f79476803e097d9fd5f7e67d45f6818348b51ac9"
+source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
 
 [[package]]
 name = "ic-nervous-system-common"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f79476803e097d9fd5f7e67d45f6818348b51ac9#f79476803e097d9fd5f7e67d45f6818348b51ac9"
+source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
 dependencies = [
  "async-trait",
  "base64 0.13.1",
@@ -3265,12 +3270,12 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-common-build-metadata"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f79476803e097d9fd5f7e67d45f6818348b51ac9#f79476803e097d9fd5f7e67d45f6818348b51ac9"
+source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
 
 [[package]]
 name = "ic-nervous-system-common-test-keys"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f79476803e097d9fd5f7e67d45f6818348b51ac9#f79476803e097d9fd5f7e67d45f6818348b51ac9"
+source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
 dependencies = [
  "ic-base-types",
  "ic-canister-client-sender",
@@ -3283,7 +3288,7 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-governance"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=f79476803e097d9fd5f7e67d45f6818348b51ac9#f79476803e097d9fd5f7e67d45f6818348b51ac9"
+source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
 dependencies = [
  "ic-base-types",
  "ic-stable-structures",
@@ -3295,7 +3300,7 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-humanize"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f79476803e097d9fd5f7e67d45f6818348b51ac9#f79476803e097d9fd5f7e67d45f6818348b51ac9"
+source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
 dependencies = [
  "humantime",
  "ic-nervous-system-proto",
@@ -3307,12 +3312,12 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-lock"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=f79476803e097d9fd5f7e67d45f6818348b51ac9#f79476803e097d9fd5f7e67d45f6818348b51ac9"
+source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
 
 [[package]]
 name = "ic-nervous-system-proto"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f79476803e097d9fd5f7e67d45f6818348b51ac9#f79476803e097d9fd5f7e67d45f6818348b51ac9"
+source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
 dependencies = [
  "candid",
  "comparable",
@@ -3325,7 +3330,7 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-proxied-canister-calls-tracker"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f79476803e097d9fd5f7e67d45f6818348b51ac9#f79476803e097d9fd5f7e67d45f6818348b51ac9"
+source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
 dependencies = [
  "ic-base-types",
 ]
@@ -3333,7 +3338,7 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-root"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f79476803e097d9fd5f7e67d45f6818348b51ac9#f79476803e097d9fd5f7e67d45f6818348b51ac9"
+source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
 dependencies = [
  "candid",
  "dfn_core",
@@ -3349,7 +3354,7 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-runtime"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f79476803e097d9fd5f7e67d45f6818348b51ac9#f79476803e097d9fd5f7e67d45f6818348b51ac9"
+source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
 dependencies = [
  "async-trait",
  "candid",
@@ -3362,12 +3367,12 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-string"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=f79476803e097d9fd5f7e67d45f6818348b51ac9#f79476803e097d9fd5f7e67d45f6818348b51ac9"
+source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
 
 [[package]]
 name = "ic-neurons-fund"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=f79476803e097d9fd5f7e67d45f6818348b51ac9#f79476803e097d9fd5f7e67d45f6818348b51ac9"
+source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
 dependencies = [
  "ic-nervous-system-common",
  "lazy_static",
@@ -3380,7 +3385,7 @@ dependencies = [
 [[package]]
 name = "ic-nns-common"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f79476803e097d9fd5f7e67d45f6818348b51ac9#f79476803e097d9fd5f7e67d45f6818348b51ac9"
+source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
 dependencies = [
  "candid",
  "comparable",
@@ -3406,15 +3411,16 @@ dependencies = [
 [[package]]
 name = "ic-nns-constants"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f79476803e097d9fd5f7e67d45f6818348b51ac9#f79476803e097d9fd5f7e67d45f6818348b51ac9"
+source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
 dependencies = [
  "ic-base-types",
+ "maplit",
 ]
 
 [[package]]
 name = "ic-nns-governance"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f79476803e097d9fd5f7e67d45f6818348b51ac9#f79476803e097d9fd5f7e67d45f6818348b51ac9"
+source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
 dependencies = [
  "async-trait",
  "build-info",
@@ -3477,12 +3483,12 @@ dependencies = [
 [[package]]
 name = "ic-nns-gtc-accounts"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f79476803e097d9fd5f7e67d45f6818348b51ac9#f79476803e097d9fd5f7e67d45f6818348b51ac9"
+source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
 
 [[package]]
 name = "ic-nns-handler-root-interface"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=f79476803e097d9fd5f7e67d45f6818348b51ac9#f79476803e097d9fd5f7e67d45f6818348b51ac9"
+source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
 dependencies = [
  "async-trait",
  "candid",
@@ -3497,7 +3503,7 @@ dependencies = [
 [[package]]
 name = "ic-protobuf"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f79476803e097d9fd5f7e67d45f6818348b51ac9#f79476803e097d9fd5f7e67d45f6818348b51ac9"
+source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
 dependencies = [
  "bincode",
  "candid",
@@ -3512,7 +3518,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-keys"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f79476803e097d9fd5f7e67d45f6818348b51ac9#f79476803e097d9fd5f7e67d45f6818348b51ac9"
+source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
 dependencies = [
  "candid",
  "ic-base-types",
@@ -3524,7 +3530,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-routing-table"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f79476803e097d9fd5f7e67d45f6818348b51ac9#f79476803e097d9fd5f7e67d45f6818348b51ac9"
+source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
 dependencies = [
  "candid",
  "ic-base-types",
@@ -3535,7 +3541,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-subnet-features"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f79476803e097d9fd5f7e67d45f6818348b51ac9#f79476803e097d9fd5f7e67d45f6818348b51ac9"
+source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
 dependencies = [
  "candid",
  "ic-management-canister-types",
@@ -3546,7 +3552,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-subnet-type"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f79476803e097d9fd5f7e67d45f6818348b51ac9#f79476803e097d9fd5f7e67d45f6818348b51ac9"
+source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
 dependencies = [
  "candid",
  "ic-protobuf",
@@ -3558,7 +3564,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-transport"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f79476803e097d9fd5f7e67d45f6818348b51ac9#f79476803e097d9fd5f7e67d45f6818348b51ac9"
+source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
 dependencies = [
  "candid",
  "ic-base-types",
@@ -3570,7 +3576,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-cli"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f79476803e097d9fd5f7e67d45f6818348b51ac9#f79476803e097d9fd5f7e67d45f6818348b51ac9"
+source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
 dependencies = [
  "anyhow",
  "base64 0.13.1",
@@ -3602,7 +3608,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-governance"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f79476803e097d9fd5f7e67d45f6818348b51ac9#f79476803e097d9fd5f7e67d45f6818348b51ac9"
+source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
 dependencies = [
  "async-trait",
  "base64 0.13.1",
@@ -3659,7 +3665,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-governance-proposal-criticality"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=f79476803e097d9fd5f7e67d45f6818348b51ac9#f79476803e097d9fd5f7e67d45f6818348b51ac9"
+source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
 dependencies = [
  "ic-nervous-system-proto",
 ]
@@ -3667,7 +3673,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-governance-proposals-amount-total-limit"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=f79476803e097d9fd5f7e67d45f6818348b51ac9#f79476803e097d9fd5f7e67d45f6818348b51ac9"
+source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
 dependencies = [
  "ic-sns-governance-token-valuation",
  "num-traits",
@@ -3678,7 +3684,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-governance-token-valuation"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=f79476803e097d9fd5f7e67d45f6818348b51ac9#f79476803e097d9fd5f7e67d45f6818348b51ac9"
+source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
 dependencies = [
  "async-trait",
  "candid",
@@ -3699,7 +3705,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-init"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f79476803e097d9fd5f7e67d45f6818348b51ac9#f79476803e097d9fd5f7e67d45f6818348b51ac9"
+source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
 dependencies = [
  "base64 0.13.1",
  "candid",
@@ -3726,7 +3732,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-root"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f79476803e097d9fd5f7e67d45f6818348b51ac9#f79476803e097d9fd5f7e67d45f6818348b51ac9"
+source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
 dependencies = [
  "async-trait",
  "build-info",
@@ -3755,7 +3761,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-swap"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f79476803e097d9fd5f7e67d45f6818348b51ac9#f79476803e097d9fd5f7e67d45f6818348b51ac9"
+source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
 dependencies = [
  "async-trait",
  "build-info",
@@ -3793,7 +3799,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-swap-proto-library"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=f79476803e097d9fd5f7e67d45f6818348b51ac9#f79476803e097d9fd5f7e67d45f6818348b51ac9"
+source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
 dependencies = [
  "candid",
  "comparable",
@@ -3808,7 +3814,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-wasm"
 version = "1.0.0"
-source = "git+https://github.com/dfinity/ic?rev=f79476803e097d9fd5f7e67d45f6818348b51ac9#f79476803e097d9fd5f7e67d45f6818348b51ac9"
+source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
 dependencies = [
  "async-trait",
  "candid",
@@ -3871,7 +3877,7 @@ dependencies = [
 [[package]]
 name = "ic-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f79476803e097d9fd5f7e67d45f6818348b51ac9#f79476803e097d9fd5f7e67d45f6818348b51ac9"
+source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
 dependencies = [
  "base64 0.13.1",
  "bincode",
@@ -3906,7 +3912,7 @@ dependencies = [
 [[package]]
 name = "ic-utils"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f79476803e097d9fd5f7e67d45f6818348b51ac9#f79476803e097d9fd5f7e67d45f6818348b51ac9"
+source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
 dependencies = [
  "hex",
  "prost",
@@ -4018,7 +4024,7 @@ dependencies = [
 [[package]]
 name = "icp-ledger"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f79476803e097d9fd5f7e67d45f6818348b51ac9#f79476803e097d9fd5f7e67d45f6818348b51ac9"
+source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
 dependencies = [
  "candid",
  "comparable",
@@ -4028,6 +4034,7 @@ dependencies = [
  "dfn_protobuf",
  "hex",
  "ic-base-types",
+ "ic-cdk",
  "ic-crypto-sha2",
  "ic-ledger-canister-core",
  "ic-ledger-core",
@@ -4048,7 +4055,7 @@ dependencies = [
 [[package]]
 name = "icrc-ledger-client"
 version = "0.1.2"
-source = "git+https://github.com/dfinity/ic?rev=f79476803e097d9fd5f7e67d45f6818348b51ac9#f79476803e097d9fd5f7e67d45f6818348b51ac9"
+source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
 dependencies = [
  "async-trait",
  "candid",
@@ -4059,7 +4066,7 @@ dependencies = [
 [[package]]
 name = "icrc-ledger-types"
 version = "0.1.5"
-source = "git+https://github.com/dfinity/ic?rev=f79476803e097d9fd5f7e67d45f6818348b51ac9#f79476803e097d9fd5f7e67d45f6818348b51ac9"
+source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
 dependencies = [
  "base32",
  "candid",
@@ -4071,6 +4078,7 @@ dependencies = [
  "serde",
  "serde_bytes",
  "sha2 0.10.8",
+ "strum 0.26.2",
 ]
 
 [[package]]
@@ -4733,9 +4741,9 @@ dependencies = [
 
 [[package]]
 name = "oid-registry"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bedf36ffb6ba96c2eb7144ef6270557b52e54b20c0a8e1eb2ff99a6c6959bff"
+checksum = "1c958dd45046245b9c3c2547369bb634eb461670b2e7e0de552905801a648d1d"
 dependencies = [
  "asn1-rs",
 ]
@@ -4743,7 +4751,7 @@ dependencies = [
 [[package]]
 name = "on_wire"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f79476803e097d9fd5f7e67d45f6818348b51ac9#f79476803e097d9fd5f7e67d45f6818348b51ac9"
+source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
 
 [[package]]
 name = "once_cell"
@@ -4994,7 +5002,7 @@ dependencies = [
 [[package]]
 name = "phantom_newtype"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f79476803e097d9fd5f7e67d45f6818348b51ac9#f79476803e097d9fd5f7e67d45f6818348b51ac9"
+source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
 dependencies = [
  "candid",
  "serde",
@@ -5456,7 +5464,7 @@ checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
 [[package]]
 name = "registry-canister"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f79476803e097d9fd5f7e67d45f6818348b51ac9#f79476803e097d9fd5f7e67d45f6818348b51ac9"
+source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
 dependencies = [
  "build-info",
  "build-info-build",
@@ -6491,14 +6499,13 @@ checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
 name = "synstructure"
-version = "0.12.6"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
+checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
- "unicode-xid",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -6909,12 +6916,6 @@ name = "unicode-width"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68f5e5f3158ecfd4b8ff6fe086db7c8467a2dfdac97fe420f2b7c4aa97af66d6"
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 
 [[package]]
 name = "universal-hash"
@@ -7391,9 +7392,9 @@ dependencies = [
 
 [[package]]
 name = "x509-parser"
-version = "0.15.1"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7069fba5b66b9193bd2c5d3d4ff12b839118f6bcbef5328efafafb5395cf63da"
+checksum = "fcbc162f30700d6f3f82a24bf7cc62ffe7caea42c0b2cba8bf7f3ae50cf51f69"
 dependencies = [
  "asn1-rs",
  "data-encoding",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1190,7 +1190,7 @@ dependencies = [
 [[package]]
 name = "cycles-minting-canister"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
+source = "git+https://github.com/dfinity/ic?rev=a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a#a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a"
 dependencies = [
  "async-trait",
  "base64 0.13.1",
@@ -1347,7 +1347,7 @@ dependencies = [
 [[package]]
 name = "dfn_candid"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
+source = "git+https://github.com/dfinity/ic?rev=a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a#a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a"
 dependencies = [
  "candid",
  "dfn_core",
@@ -1359,7 +1359,7 @@ dependencies = [
 [[package]]
 name = "dfn_core"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
+source = "git+https://github.com/dfinity/ic?rev=a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a#a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a"
 dependencies = [
  "ic-base-types",
  "on_wire",
@@ -1368,7 +1368,7 @@ dependencies = [
 [[package]]
 name = "dfn_http"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
+source = "git+https://github.com/dfinity/ic?rev=a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a#a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a"
 dependencies = [
  "candid",
  "dfn_candid",
@@ -1380,7 +1380,7 @@ dependencies = [
 [[package]]
 name = "dfn_http_metrics"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
+source = "git+https://github.com/dfinity/ic?rev=a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a#a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a"
 dependencies = [
  "dfn_candid",
  "dfn_core",
@@ -1392,7 +1392,7 @@ dependencies = [
 [[package]]
 name = "dfn_protobuf"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
+source = "git+https://github.com/dfinity/ic?rev=a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a#a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a"
 dependencies = [
  "on_wire",
  "prost",
@@ -1798,7 +1798,7 @@ checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
 [[package]]
 name = "fe-derive"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
+source = "git+https://github.com/dfinity/ic?rev=a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a#a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a"
 dependencies = [
  "hex",
  "num-bigint-dig",
@@ -2536,7 +2536,7 @@ dependencies = [
 [[package]]
 name = "ic-base-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
+source = "git+https://github.com/dfinity/ic?rev=a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a#a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a"
 dependencies = [
  "byte-unit",
  "bytes",
@@ -2563,7 +2563,7 @@ dependencies = [
 [[package]]
 name = "ic-btc-types-internal"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
+source = "git+https://github.com/dfinity/ic?rev=a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a#a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a"
 dependencies = [
  "candid",
  "ic-btc-interface",
@@ -2576,7 +2576,7 @@ dependencies = [
 [[package]]
 name = "ic-canister-client-sender"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
+source = "git+https://github.com/dfinity/ic?rev=a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a#a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a"
 dependencies = [
  "ic-base-types",
  "ic-crypto-ecdsa-secp256k1",
@@ -2589,7 +2589,7 @@ dependencies = [
 [[package]]
 name = "ic-canister-log"
 version = "0.2.0"
-source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
+source = "git+https://github.com/dfinity/ic?rev=a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a#a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a"
 dependencies = [
  "serde",
 ]
@@ -2597,7 +2597,7 @@ dependencies = [
 [[package]]
 name = "ic-canister-profiler"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
+source = "git+https://github.com/dfinity/ic?rev=a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a#a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a"
 dependencies = [
  "ic-metrics-encoder",
  "ic0 0.18.11",
@@ -2606,7 +2606,7 @@ dependencies = [
 [[package]]
 name = "ic-canisters-http-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
+source = "git+https://github.com/dfinity/ic?rev=a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a#a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a"
 dependencies = [
  "candid",
  "serde",
@@ -2694,12 +2694,12 @@ dependencies = [
 [[package]]
 name = "ic-constants"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
+source = "git+https://github.com/dfinity/ic?rev=a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a#a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a"
 
 [[package]]
 name = "ic-crypto-ecdsa-secp256k1"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
+source = "git+https://github.com/dfinity/ic?rev=a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a#a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a"
 dependencies = [
  "k256 0.13.3",
  "lazy_static",
@@ -2713,7 +2713,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-ed25519"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
+source = "git+https://github.com/dfinity/ic?rev=a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a#a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a"
 dependencies = [
  "curve25519-dalek",
  "ed25519-dalek",
@@ -2727,7 +2727,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-getrandom-for-wasm"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
+source = "git+https://github.com/dfinity/ic?rev=a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a#a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a"
 dependencies = [
  "getrandom",
 ]
@@ -2735,7 +2735,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-basic-sig-der-utils"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
+source = "git+https://github.com/dfinity/ic?rev=a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a#a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a"
 dependencies = [
  "hex",
  "ic-types",
@@ -2745,7 +2745,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-basic-sig-ed25519"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
+source = "git+https://github.com/dfinity/ic?rev=a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a#a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a"
 dependencies = [
  "base64 0.13.1",
  "curve25519-dalek",
@@ -2767,7 +2767,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-bls12-381-type"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
+source = "git+https://github.com/dfinity/ic?rev=a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a#a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a"
 dependencies = [
  "hex",
  "ic_bls12_381",
@@ -2785,7 +2785,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-hmac"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
+source = "git+https://github.com/dfinity/ic?rev=a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a#a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a"
 dependencies = [
  "ic-crypto-internal-sha2",
 ]
@@ -2793,7 +2793,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-multi-sig-bls12381"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
+source = "git+https://github.com/dfinity/ic?rev=a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a#a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a"
 dependencies = [
  "base64 0.13.1",
  "hex",
@@ -2812,7 +2812,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-seed"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
+source = "git+https://github.com/dfinity/ic?rev=a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a#a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a"
 dependencies = [
  "hex",
  "ic-crypto-sha2",
@@ -2825,7 +2825,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-sha2"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
+source = "git+https://github.com/dfinity/ic?rev=a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a#a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a"
 dependencies = [
  "sha2 0.10.8",
 ]
@@ -2833,7 +2833,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-threshold-sig-bls12381"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
+source = "git+https://github.com/dfinity/ic?rev=a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a#a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a"
 dependencies = [
  "base64 0.13.1",
  "cached 0.49.3",
@@ -2859,7 +2859,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-threshold-sig-ecdsa"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
+source = "git+https://github.com/dfinity/ic?rev=a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a#a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a"
 dependencies = [
  "curve25519-dalek",
  "fe-derive",
@@ -2889,7 +2889,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
+source = "git+https://github.com/dfinity/ic?rev=a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a#a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a"
 dependencies = [
  "arrayvec 0.7.4",
  "hex",
@@ -2906,7 +2906,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-node-key-validation"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
+source = "git+https://github.com/dfinity/ic?rev=a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a#a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a"
 dependencies = [
  "hex",
  "ic-base-types",
@@ -2924,7 +2924,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-secrets-containers"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
+source = "git+https://github.com/dfinity/ic?rev=a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a#a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a"
 dependencies = [
  "serde",
  "zeroize",
@@ -2933,7 +2933,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-sha2"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
+source = "git+https://github.com/dfinity/ic?rev=a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a#a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a"
 dependencies = [
  "ic-crypto-internal-sha2",
 ]
@@ -2941,7 +2941,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-test-utils-reproducible-rng"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
+source = "git+https://github.com/dfinity/ic?rev=a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a#a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a"
 dependencies = [
  "rand",
  "rand_chacha",
@@ -2950,7 +2950,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-tls-cert-validation"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
+source = "git+https://github.com/dfinity/ic?rev=a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a#a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a"
 dependencies = [
  "hex",
  "ic-crypto-internal-basic-sig-ed25519",
@@ -2964,7 +2964,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-tree-hash"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
+source = "git+https://github.com/dfinity/ic?rev=a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a#a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a"
 dependencies = [
  "assert_matches",
  "ic-crypto-internal-types",
@@ -2978,7 +2978,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-utils-basic-sig"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
+source = "git+https://github.com/dfinity/ic?rev=a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a#a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a"
 dependencies = [
  "ic-base-types",
  "ic-crypto-ed25519",
@@ -2988,7 +2988,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-utils-ni-dkg"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
+source = "git+https://github.com/dfinity/ic?rev=a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a#a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a"
 dependencies = [
  "ic-crypto-internal-types",
  "ic-protobuf",
@@ -2998,7 +2998,7 @@ dependencies = [
 [[package]]
 name = "ic-error-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
+source = "git+https://github.com/dfinity/ic?rev=a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a#a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a"
 dependencies = [
  "ic-protobuf",
  "ic-utils 0.9.0",
@@ -3010,7 +3010,7 @@ dependencies = [
 [[package]]
 name = "ic-icp-index"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
+source = "git+https://github.com/dfinity/ic?rev=a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a#a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a"
 dependencies = [
  "candid",
  "ciborium",
@@ -3038,7 +3038,7 @@ dependencies = [
 [[package]]
 name = "ic-icrc1"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
+source = "git+https://github.com/dfinity/ic?rev=a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a#a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a"
 dependencies = [
  "candid",
  "ciborium",
@@ -3060,7 +3060,7 @@ dependencies = [
 [[package]]
 name = "ic-icrc1-index-ng"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
+source = "git+https://github.com/dfinity/ic?rev=a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a#a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a"
 dependencies = [
  "candid",
  "ciborium",
@@ -3088,7 +3088,7 @@ dependencies = [
 [[package]]
 name = "ic-icrc1-ledger"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
+source = "git+https://github.com/dfinity/ic?rev=a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a#a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a"
 dependencies = [
  "async-trait",
  "candid",
@@ -3116,7 +3116,7 @@ dependencies = [
 [[package]]
 name = "ic-icrc1-tokens-u64"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
+source = "git+https://github.com/dfinity/ic?rev=a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a#a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a"
 dependencies = [
  "candid",
  "ic-ledger-core",
@@ -3141,7 +3141,7 @@ dependencies = [
 [[package]]
 name = "ic-ledger-canister-core"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
+source = "git+https://github.com/dfinity/ic?rev=a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a#a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a"
 dependencies = [
  "async-trait",
  "candid",
@@ -3159,7 +3159,7 @@ dependencies = [
 [[package]]
 name = "ic-ledger-core"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
+source = "git+https://github.com/dfinity/ic?rev=a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a#a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a"
 dependencies = [
  "candid",
  "ic-ledger-hash-of",
@@ -3171,7 +3171,7 @@ dependencies = [
 [[package]]
 name = "ic-ledger-hash-of"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
+source = "git+https://github.com/dfinity/ic?rev=a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a#a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a"
 dependencies = [
  "candid",
  "hex",
@@ -3181,7 +3181,7 @@ dependencies = [
 [[package]]
 name = "ic-management-canister-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
+source = "git+https://github.com/dfinity/ic?rev=a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a#a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a"
 dependencies = [
  "candid",
  "ic-base-types",
@@ -3206,7 +3206,7 @@ checksum = "8b5c7628eac357aecda461130f8074468be5aa4d258a002032d82d817f79f1f8"
 [[package]]
 name = "ic-nervous-system-clients"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
+source = "git+https://github.com/dfinity/ic?rev=a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a#a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a"
 dependencies = [
  "async-trait",
  "candid",
@@ -3229,12 +3229,12 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-collections-union-multi-map"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
+source = "git+https://github.com/dfinity/ic?rev=a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a#a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a"
 
 [[package]]
 name = "ic-nervous-system-common"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
+source = "git+https://github.com/dfinity/ic?rev=a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a#a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a"
 dependencies = [
  "async-trait",
  "base64 0.13.1",
@@ -3270,12 +3270,12 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-common-build-metadata"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
+source = "git+https://github.com/dfinity/ic?rev=a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a#a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a"
 
 [[package]]
 name = "ic-nervous-system-common-test-keys"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
+source = "git+https://github.com/dfinity/ic?rev=a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a#a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a"
 dependencies = [
  "ic-base-types",
  "ic-canister-client-sender",
@@ -3288,7 +3288,7 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-governance"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
+source = "git+https://github.com/dfinity/ic?rev=a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a#a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a"
 dependencies = [
  "ic-base-types",
  "ic-stable-structures",
@@ -3300,7 +3300,7 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-humanize"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
+source = "git+https://github.com/dfinity/ic?rev=a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a#a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a"
 dependencies = [
  "humantime",
  "ic-nervous-system-proto",
@@ -3312,12 +3312,12 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-lock"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
+source = "git+https://github.com/dfinity/ic?rev=a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a#a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a"
 
 [[package]]
 name = "ic-nervous-system-proto"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
+source = "git+https://github.com/dfinity/ic?rev=a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a#a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a"
 dependencies = [
  "candid",
  "comparable",
@@ -3330,7 +3330,7 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-proxied-canister-calls-tracker"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
+source = "git+https://github.com/dfinity/ic?rev=a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a#a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a"
 dependencies = [
  "ic-base-types",
 ]
@@ -3338,7 +3338,7 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-root"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
+source = "git+https://github.com/dfinity/ic?rev=a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a#a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a"
 dependencies = [
  "candid",
  "dfn_core",
@@ -3354,7 +3354,7 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-runtime"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
+source = "git+https://github.com/dfinity/ic?rev=a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a#a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a"
 dependencies = [
  "async-trait",
  "candid",
@@ -3367,12 +3367,12 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-string"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
+source = "git+https://github.com/dfinity/ic?rev=a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a#a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a"
 
 [[package]]
 name = "ic-neurons-fund"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
+source = "git+https://github.com/dfinity/ic?rev=a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a#a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a"
 dependencies = [
  "ic-nervous-system-common",
  "lazy_static",
@@ -3385,7 +3385,7 @@ dependencies = [
 [[package]]
 name = "ic-nns-common"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
+source = "git+https://github.com/dfinity/ic?rev=a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a#a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a"
 dependencies = [
  "candid",
  "comparable",
@@ -3411,7 +3411,7 @@ dependencies = [
 [[package]]
 name = "ic-nns-constants"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
+source = "git+https://github.com/dfinity/ic?rev=a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a#a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a"
 dependencies = [
  "ic-base-types",
  "maplit",
@@ -3420,7 +3420,7 @@ dependencies = [
 [[package]]
 name = "ic-nns-governance"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
+source = "git+https://github.com/dfinity/ic?rev=a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a#a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a"
 dependencies = [
  "async-trait",
  "build-info",
@@ -3483,12 +3483,12 @@ dependencies = [
 [[package]]
 name = "ic-nns-gtc-accounts"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
+source = "git+https://github.com/dfinity/ic?rev=a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a#a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a"
 
 [[package]]
 name = "ic-nns-handler-root-interface"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
+source = "git+https://github.com/dfinity/ic?rev=a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a#a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a"
 dependencies = [
  "async-trait",
  "candid",
@@ -3503,7 +3503,7 @@ dependencies = [
 [[package]]
 name = "ic-protobuf"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
+source = "git+https://github.com/dfinity/ic?rev=a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a#a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a"
 dependencies = [
  "bincode",
  "candid",
@@ -3518,7 +3518,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-keys"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
+source = "git+https://github.com/dfinity/ic?rev=a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a#a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a"
 dependencies = [
  "candid",
  "ic-base-types",
@@ -3530,7 +3530,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-routing-table"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
+source = "git+https://github.com/dfinity/ic?rev=a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a#a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a"
 dependencies = [
  "candid",
  "ic-base-types",
@@ -3541,7 +3541,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-subnet-features"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
+source = "git+https://github.com/dfinity/ic?rev=a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a#a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a"
 dependencies = [
  "candid",
  "ic-management-canister-types",
@@ -3552,7 +3552,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-subnet-type"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
+source = "git+https://github.com/dfinity/ic?rev=a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a#a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a"
 dependencies = [
  "candid",
  "ic-protobuf",
@@ -3564,7 +3564,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-transport"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
+source = "git+https://github.com/dfinity/ic?rev=a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a#a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a"
 dependencies = [
  "candid",
  "ic-base-types",
@@ -3576,7 +3576,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-cli"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
+source = "git+https://github.com/dfinity/ic?rev=a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a#a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a"
 dependencies = [
  "anyhow",
  "base64 0.13.1",
@@ -3608,7 +3608,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-governance"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
+source = "git+https://github.com/dfinity/ic?rev=a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a#a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a"
 dependencies = [
  "async-trait",
  "base64 0.13.1",
@@ -3665,7 +3665,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-governance-proposal-criticality"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
+source = "git+https://github.com/dfinity/ic?rev=a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a#a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a"
 dependencies = [
  "ic-nervous-system-proto",
 ]
@@ -3673,7 +3673,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-governance-proposals-amount-total-limit"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
+source = "git+https://github.com/dfinity/ic?rev=a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a#a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a"
 dependencies = [
  "ic-sns-governance-token-valuation",
  "num-traits",
@@ -3684,7 +3684,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-governance-token-valuation"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
+source = "git+https://github.com/dfinity/ic?rev=a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a#a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a"
 dependencies = [
  "async-trait",
  "candid",
@@ -3705,7 +3705,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-init"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
+source = "git+https://github.com/dfinity/ic?rev=a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a#a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a"
 dependencies = [
  "base64 0.13.1",
  "candid",
@@ -3732,7 +3732,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-root"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
+source = "git+https://github.com/dfinity/ic?rev=a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a#a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a"
 dependencies = [
  "async-trait",
  "build-info",
@@ -3761,7 +3761,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-swap"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
+source = "git+https://github.com/dfinity/ic?rev=a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a#a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a"
 dependencies = [
  "async-trait",
  "build-info",
@@ -3799,7 +3799,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-swap-proto-library"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
+source = "git+https://github.com/dfinity/ic?rev=a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a#a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a"
 dependencies = [
  "candid",
  "comparable",
@@ -3814,7 +3814,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-wasm"
 version = "1.0.0"
-source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
+source = "git+https://github.com/dfinity/ic?rev=a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a#a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a"
 dependencies = [
  "async-trait",
  "candid",
@@ -3877,7 +3877,7 @@ dependencies = [
 [[package]]
 name = "ic-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
+source = "git+https://github.com/dfinity/ic?rev=a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a#a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a"
 dependencies = [
  "base64 0.13.1",
  "bincode",
@@ -3912,7 +3912,7 @@ dependencies = [
 [[package]]
 name = "ic-utils"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
+source = "git+https://github.com/dfinity/ic?rev=a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a#a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a"
 dependencies = [
  "hex",
  "prost",
@@ -4024,7 +4024,7 @@ dependencies = [
 [[package]]
 name = "icp-ledger"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
+source = "git+https://github.com/dfinity/ic?rev=a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a#a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a"
 dependencies = [
  "candid",
  "comparable",
@@ -4055,7 +4055,7 @@ dependencies = [
 [[package]]
 name = "icrc-ledger-client"
 version = "0.1.2"
-source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
+source = "git+https://github.com/dfinity/ic?rev=a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a#a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a"
 dependencies = [
  "async-trait",
  "candid",
@@ -4066,7 +4066,7 @@ dependencies = [
 [[package]]
 name = "icrc-ledger-types"
 version = "0.1.5"
-source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
+source = "git+https://github.com/dfinity/ic?rev=a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a#a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a"
 dependencies = [
  "base32",
  "candid",
@@ -4751,7 +4751,7 @@ dependencies = [
 [[package]]
 name = "on_wire"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
+source = "git+https://github.com/dfinity/ic?rev=a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a#a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a"
 
 [[package]]
 name = "once_cell"
@@ -5002,7 +5002,7 @@ dependencies = [
 [[package]]
 name = "phantom_newtype"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
+source = "git+https://github.com/dfinity/ic?rev=a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a#a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a"
 dependencies = [
  "candid",
  "serde",
@@ -5464,7 +5464,7 @@ checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
 [[package]]
 name = "registry-canister"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0#6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0"
+source = "git+https://github.com/dfinity/ic?rev=a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a#a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a"
 dependencies = [
  "build-info",
  "build-info-build",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,10 +34,10 @@ slog = "^2.7.0"
 tempfile = "3.5.0"
 tokio = { version = "^1.36.0", features = ["rt-multi-thread"] }
 url = "^2.4.1"
-ic-icp-index = { git = "https://github.com/dfinity/ic", rev = "6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0" }
-ic-icrc1-index-ng = { git = "https://github.com/dfinity/ic", rev = "6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0" }
-ic-icrc1-ledger = { git = "https://github.com/dfinity/ic", rev = "6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0" }
-ic-sns-cli = { git = "https://github.com/dfinity/ic", rev = "6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0" }
+ic-icp-index = { git = "https://github.com/dfinity/ic", rev = "a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a" }
+ic-icrc1-index-ng = { git = "https://github.com/dfinity/ic", rev = "a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a" }
+ic-icrc1-ledger = { git = "https://github.com/dfinity/ic", rev = "a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a" }
+ic-sns-cli = { git = "https://github.com/dfinity/ic", rev = "a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a" }
 
 # Config for 'cargo dist'
 [workspace.metadata.dist]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,10 +34,10 @@ slog = "^2.7.0"
 tempfile = "3.5.0"
 tokio = { version = "^1.36.0", features = ["rt-multi-thread"] }
 url = "^2.4.1"
-ic-icp-index = { git = "https://github.com/dfinity/ic", rev = "f79476803e097d9fd5f7e67d45f6818348b51ac9" }
-ic-icrc1-index-ng = { git = "https://github.com/dfinity/ic", rev = "f79476803e097d9fd5f7e67d45f6818348b51ac9" }
-ic-icrc1-ledger = { git = "https://github.com/dfinity/ic", rev = "f79476803e097d9fd5f7e67d45f6818348b51ac9" }
-ic-sns-cli = { git = "https://github.com/dfinity/ic", rev = "f79476803e097d9fd5f7e67d45f6818348b51ac9" }
+ic-icp-index = { git = "https://github.com/dfinity/ic", rev = "6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0" }
+ic-icrc1-index-ng = { git = "https://github.com/dfinity/ic", rev = "6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0" }
+ic-icrc1-ledger = { git = "https://github.com/dfinity/ic", rev = "6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0" }
+ic-sns-cli = { git = "https://github.com/dfinity/ic", rev = "6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0" }
 
 # Config for 'cargo dist'
 [workspace.metadata.dist]

--- a/extensions/nns/build.rs
+++ b/extensions/nns/build.rs
@@ -1,7 +1,7 @@
 use std::env;
 use std::path::PathBuf;
 
-const REPLICA_REV: &str = "6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0";
+const REPLICA_REV: &str = "a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a";
 
 const BINARY_DEPENDENCIES: &[(&str, &str)] = &[
     // (downloaded binary name, renamed binary name)

--- a/extensions/nns/build.rs
+++ b/extensions/nns/build.rs
@@ -1,7 +1,7 @@
 use std::env;
 use std::path::PathBuf;
 
-const REPLICA_REV: &str = "f79476803e097d9fd5f7e67d45f6818348b51ac9";
+const REPLICA_REV: &str = "6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0";
 
 const BINARY_DEPENDENCIES: &[(&str, &str)] = &[
     // (downloaded binary name, renamed binary name)

--- a/extensions/sns/CHANGELOG.md
+++ b/extensions/sns/CHANGELOG.md
@@ -1,6 +1,7 @@
 <!-- next-header -->
 
 ## [Unreleased] - ReleaseDate
+- Added the `neuron-id-to-candid-subaccount` command.
 
 ## [0.4.1] - 2024-05-29
 - The `Principals` field of sns-init.yaml is no longer required.

--- a/extensions/sns/README.md
+++ b/extensions/sns/README.md
@@ -9,13 +9,14 @@ dfx sns [subcommand] [flag]
 
 Depending on the `dfx sns` subcommand you specify, additional arguments, options, and flags might apply. For reference information and examples that illustrate using `dfx sns` commands, select an appropriate command.
 
-| Command                                                            | Description                                                                                        |
-| ------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------- |
-| [`init-config-file validate`](#_dfx_sns_init-config-file_validate) | Checks whether the sns config file is valid.                                                       |
-| [`deploy-testflight`](#_dfx_sns_deploy-testflight)                 | Creates a test deployment of the SNS canisters according to the local config.                      |
-| [`prepare-canisters`](#_dfx_sns_prepare-canisters)                 | Prepares dapp canister(s) for SNS decentralization by adding NNS root as one of their controllers. |
-| [`propose`](#_dfx_sns_propose)                                     | Submits a CreateServiceNervousSystem NNS Proposal.                                                 |
-| `help`                                                             | Displays usage information message for a specified subcommand.                                     |
+| Command                                                            | Description                                                                                                        |
+| ------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------ |
+| [`init-config-file validate`](#_dfx_sns_init-config-file_validate) | Checks whether the sns config file is valid.                                                                       |
+| [`deploy-testflight`](#_dfx_sns_deploy-testflight)                 | Creates a test deployment of the SNS canisters according to the local config.                                      |
+| [`prepare-canisters`](#_dfx_sns_prepare-canisters)                 | Prepares dapp canister(s) for SNS decentralization by adding NNS root as one of their controllers.                 |
+| [`propose`](#_dfx_sns_propose)                                     | Submits a CreateServiceNervousSystem NNS Proposal.                                                                 |
+| [`neuron-id-to-candid-subaccount`](#_dfx_sns_propose)              | Converts a Neuron ID to a candid subaccount blob suitable for use in the `manage_neuron` method on SNS Governance. |
+| `help`                                                             | Displays usage information message for a specified subcommand.                                                     |
 
 To view usage information for a specific subcommand, specify the subcommand and the `--help` flag. For example, to see usage information for `dfx sns validate`, you can run the following command:
 

--- a/extensions/sns/build.rs
+++ b/extensions/sns/build.rs
@@ -1,7 +1,7 @@
 use std::env;
 use std::path::PathBuf;
 
-const REPLICA_REV: &str = "6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0";
+const REPLICA_REV: &str = "a28a0e631c0910b371d1c40b2c6e2d09cb4fd42a";
 
 const BINARY_DEPENDENCIES: &[(&str, &str)] = &[
     // (downloaded binary name, renamed binary name)

--- a/extensions/sns/build.rs
+++ b/extensions/sns/build.rs
@@ -1,7 +1,7 @@
 use std::env;
 use std::path::PathBuf;
 
-const REPLICA_REV: &str = "f79476803e097d9fd5f7e67d45f6818348b51ac9";
+const REPLICA_REV: &str = "6c90cbe9d9db0f4f2ca5260b98e52dd4a2d132b0";
 
 const BINARY_DEPENDENCIES: &[(&str, &str)] = &[
     // (downloaded binary name, renamed binary name)

--- a/extensions/sns/e2e/tests/sns.bash
+++ b/extensions/sns/e2e/tests/sns.bash
@@ -206,3 +206,14 @@ SNS_CONFIG_FILE_NAME="sns_init.yaml"
     assert_output --partial "🚀 Success!"
     assert_output --partial "Proposal ID"
 }
+
+# This test asserts that the `neuron-id-to-candid-subaccount` subcommand exist in the current extension version.
+@test "sns neuron-id-to-candid-subaccount exists" {
+    run dfx sns neuron-id-to-candid-subaccount --help
+    assert_output --partial "Converts a Neuron ID to a candid subaccount blob"
+}
+# check the output of a particular case of neuron-id-to-candid-subaccount
+@test "sns neuron-id-to-candid-subaccount has a reasonable output" {
+    run dfx sns neuron-id-to-candid-subaccount 9f5f9fda77a03e7177126d0be8c99e931a5381731d00da53ede363140e1be5d6
+    assert_output "blob \"\\9f\\5f\\9f\\da\\77\\a0\\3e\\71\\77\\12\\6d\\0b\\e8\\c9\\9e\\93\\1a\\53\\81\\73\\1d\\00\\da\\53\\ed\\e3\\63\\14\\0e\\1b\\e5\\d6\""
+}

--- a/extensions/sns/e2e/tests/sns.bash
+++ b/extensions/sns/e2e/tests/sns.bash
@@ -215,5 +215,9 @@ SNS_CONFIG_FILE_NAME="sns_init.yaml"
 # check the output of a particular case of neuron-id-to-candid-subaccount
 @test "sns neuron-id-to-candid-subaccount has a reasonable output" {
     run dfx sns neuron-id-to-candid-subaccount 9f5f9fda77a03e7177126d0be8c99e931a5381731d00da53ede363140e1be5d6
-    assert_output "blob \"\\9f\\5f\\9f\\da\\77\\a0\\3e\\71\\77\\12\\6d\\0b\\e8\\c9\\9e\\93\\1a\\53\\81\\73\\1d\\00\\da\\53\\ed\\e3\\63\\14\\0e\\1b\\e5\\d6\""
+    assert_output 'blob "\9f\5f\9f\da\77\a0\3e\71\77\12\6d\0b\e8\c9\9e\93\1a\53\81\73\1d\00\da\53\ed\e3\63\14\0e\1b\e5\d6"'
+}
+@test "sns neuron-id-to-candid-subaccount --escaped has a reasonable output" {
+    run dfx sns neuron-id-to-candid-subaccount 9f5f9fda77a03e7177126d0be8c99e931a5381731d00da53ede363140e1be5d6 --escaped
+    assert_output 'blob \"\\9f\\5f\\9f\\da\\77\\a0\\3e\\71\\77\\12\\6d\\0b\\e8\\c9\\9e\\93\\1a\\53\\81\\73\\1d\\00\\da\\53\\ed\\e3\\63\\14\\0e\\1b\\e5\\d6\"'
 }

--- a/extensions/sns/extension.json
+++ b/extensions/sns/extension.json
@@ -84,7 +84,8 @@
           "about": "The (hex-encoded) SNS neuron ID to convert to a candid subaccount blob"
         },
         "escaped": {
-          "about": "If true, print the escaped version of the candid string, useful for pasting into a bash script for example. Default is false"
+          "about": "If true, print the escaped version of the candid string, useful for pasting into a bash script for example. Default is false",
+          "long": "escaped"
         }
       }
     },

--- a/extensions/sns/extension.json
+++ b/extensions/sns/extension.json
@@ -85,7 +85,8 @@
         },
         "escaped": {
           "about": "If true, print the escaped version of the candid string, useful for pasting into a bash script for example. Default is false",
-          "long": "escaped"
+          "long": "escaped",
+          "values": 0
         }
       }
     },

--- a/extensions/sns/extension.json
+++ b/extensions/sns/extension.json
@@ -77,6 +77,17 @@
         }
       }
     },
+    "neuron-id-to-candid-subaccount": {
+      "about": "Converts a Neuron ID to a candid subaccount blob suitable for use in the `manage_neuron` method on SNS Governance",
+      "args": {
+        "neuron_id": {
+          "about": "The (hex-encoded) SNS neuron ID to convert to a candid subaccount blob"
+        },
+        "escaped": {
+          "about": "If true, print the escaped version of the candid string, useful for pasting into a bash script for example. Default is false"
+        }
+      }
+    },
     "import": {
       "about": "Subcommand for importing sns API definitions and canister IDs.",
       "args": {

--- a/extensions/sns/src/main.rs
+++ b/extensions/sns/src/main.rs
@@ -15,6 +15,7 @@ use clap::Parser;
 use ic_sns_cli::{
     deploy_testflight,
     init_config_file::{self, InitConfigFileArgs},
+    neuron_id_to_candid_subaccount::{self, NeuronIdToCandidSubaccountArgs},
     prepare_canisters::{self, PrepareCanistersArgs},
     propose::{self, ProposeArgs},
     DeployTestflightArgs,
@@ -52,6 +53,10 @@ enum SubCommand {
     /// Submit an NNS proposal to create new SNS.
     #[command()]
     Propose(ProposeArgs),
+    /// Converts a Neuron ID to a candid subaccount blob suitable for use in
+    /// the `manage_neuron` method on SNS Governance.
+    #[command()]
+    NeuronIdToCandidSubaccount(NeuronIdToCandidSubaccountArgs),
 
     /// Subcommand for importing sns API definitions and canister IDs.
     /// This and `Download` are only useful for SNS testflight
@@ -81,6 +86,10 @@ fn main() -> anyhow::Result<()> {
         }
         SubCommand::Propose(args) => {
             propose::exec(args);
+            Ok(())
+        }
+        SubCommand::NeuronIdToCandidSubaccount(args) => {
+            neuron_id_to_candid_subaccount::exec(args);
             Ok(())
         }
 


### PR DESCRIPTION
Pretty much all the implementation is already done in the ic repo, we just need to hook it up to the dfx extension