### PR TITLE
Download index-ng instead of index

### DIFF
--- a/extensions-utils/src/dependencies/download_wasms/sns.rs
+++ b/extensions-utils/src/dependencies/download_wasms/sns.rs
@@ -65,7 +65,7 @@ pub const SNS_LEDGER_ARCHIVE: SnsCanisterInstallation = SnsCanisterInstallation 
 pub const SNS_INDEX: SnsCanisterInstallation = SnsCanisterInstallation {
     canister_name: "sns-index",
     upload_name: "index",
-    wasm_name: "ic-icrc1-index.wasm",
+    wasm_name: "ic-icrc1-index-ng.wasm",
 };
 /// SNS wasm files hosted by the nns-sns-wasms canister.
 ///


### PR DESCRIPTION
`dfx sns download` downloads specified versions of the SNS canister wasms. However, it currently downloads the `index` canister wasm, while the sns uses `index-ng`. This PR fixes this discrepancy