### PR TITLE
refactor: Automatically update the SNS extension's extension.json

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,9 +155,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle-query"
-version = "1.0.3"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a64c907d4e79225ac72e2a354c9ce84d50ebb4586dee56c82b3ee73004f537f5"
+checksum = "ad186efb764318d35165f1758e7dcef3b10628e26d41a44bc5550652e6804391"
 dependencies = [
  "windows-sys 0.52.0",
 ]
@@ -174,9 +174,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.86"
+version = "1.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
+checksum = "3b13c32d80ecc7ab747b80c3784bce54ee8a7a0cc4fbda9bf4cda2cf6fe90854"
 
 [[package]]
 name = "argon2"
@@ -225,7 +225,7 @@ checksum = "7378575ff571966e99a744addeff0bff98b8ada0dedf1956d59e634db95eaac1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.68",
  "synstructure",
 ]
 
@@ -237,7 +237,7 @@ checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -271,11 +271,11 @@ dependencies = [
 
 [[package]]
 name = "async-lock"
-version = "3.3.0"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d034b430882f8381900d3fe6f0aaa3ad94f2cb4ac519b429692a1bc2dda4ae7b"
+checksum = "ff6e472cdea888a4bd64f342f09b3f50e1886d32afe8df3d663c01140b811b18"
 dependencies = [
- "event-listener 4.0.3",
+ "event-listener 5.3.1",
  "event-listener-strategy",
  "pin-project-lite",
 ]
@@ -288,7 +288,7 @@ checksum = "c6fa2087f2753a7da8cc1c0dbfcf89579dd57458e36769de5ac750b4671737ca"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -324,9 +324,9 @@ dependencies = [
 
 [[package]]
 name = "backtrace"
-version = "0.3.72"
+version = "0.3.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17c6a35df3749d2e8bb1b7b21a976d82b15548788d2735b9d82f329268f71a11"
+checksum = "5cc23269a4f8976d0a4d2e7109211a419fe30e8d88d677cd60b6bc79c5732e0a"
 dependencies = [
  "addr2line",
  "cc",
@@ -437,9 +437,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
+checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
 name = "bitvec"
@@ -505,16 +505,16 @@ dependencies = [
  "digest 0.9.0",
  "ff 0.12.1",
  "group 0.12.1",
- "pairing",
+ "pairing 0.22.0",
  "rand_core",
  "subtle",
 ]
 
 [[package]]
 name = "borsh"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbe5b10e214954177fb1dc9fbd20a1a2608fe99e6c832033bdc7cea287a20d77"
+checksum = "a6362ed55def622cddc70a4746a68554d7b687713770de539e59a739b249f8ed"
 dependencies = [
  "borsh-derive",
  "cfg_aliases",
@@ -522,15 +522,15 @@ dependencies = [
 
 [[package]]
 name = "borsh-derive"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a8646f94ab393e43e8b35a2558b1624bed28b97ee09c5d15456e3c9463f46d"
+checksum = "c3ef8005764f53cd4dca619f5bf64cafd4664dada50ece25e4d81de54c80cc0b"
 dependencies = [
  "once_cell",
  "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.68",
  "syn_derive",
 ]
 
@@ -591,7 +591,7 @@ dependencies = [
  "base64 0.13.1",
  "bincode",
  "build-info-common",
- "num-bigint 0.4.5",
+ "num-bigint 0.4.3",
  "num-traits",
  "proc-macro-error",
  "proc-macro-hack",
@@ -694,9 +694,9 @@ dependencies = [
 
 [[package]]
 name = "candid"
-version = "0.10.8"
+version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd5902d37352dffd8bd9177a2daa6444ce3cd0279c91763fb0171c053aa04335"
+checksum = "7df77a80c72fcd356cf37ff59c812f37ff06dc9a81232b3aff0a308cb5996904"
 dependencies = [
  "anyhow",
  "binread",
@@ -705,7 +705,7 @@ dependencies = [
  "hex",
  "ic_principal",
  "leb128",
- "num-bigint 0.4.5",
+ "num-bigint 0.4.3",
  "num-traits",
  "paste",
  "pretty",
@@ -724,7 +724,7 @@ dependencies = [
  "lazy_static",
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -751,9 +751,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.98"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41c270e7540d725e65ac7f1b212ac8ce349719624d7bcff99f8e2e488e8cf03f"
+checksum = "74b6a57f98764a267ff415d50a25e6e166f3831a5071af4995296ea97d210490"
 
 [[package]]
 name = "cfg-if"
@@ -763,9 +763,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "cfg_aliases"
-version = "0.1.1"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
@@ -777,7 +777,7 @@ dependencies = [
  "iana-time-zone",
  "num-traits",
  "serde",
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -845,23 +845,23 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.4"
+version = "4.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bc066a67923782aa8515dbaea16946c5bcc5addbd668bb80af688e53e548a0"
+checksum = "84b3edb18336f4df585bc9aa31dd99c036dfa5dc5e9a2939a722a188f3a8970d"
 dependencies = [
  "clap_builder",
- "clap_derive 4.5.4",
+ "clap_derive 4.5.8",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.2"
+version = "4.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae129e2e766ae0ec03484e609954119f123cc1fe650337e155d03b022f24f7b4"
+checksum = "c1c09dd5ada6c6c78075d6fd0da3f90d8080651e2d6cc8eb2f1aaa4034ced708"
 dependencies = [
  "anstream",
  "anstyle",
- "clap_lex 0.7.0",
+ "clap_lex 0.7.1",
  "strsim 0.11.1",
 ]
 
@@ -880,14 +880,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.4"
+version = "4.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "528131438037fd55894f62d6e9f068b8f45ac57ffa77517819645d10aed04f64"
+checksum = "2bac35c6dafb060fd4d275d9a4ffae97917c13a6327903a8be2153cd964f7085"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -901,9 +901,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
+checksum = "4b82cf0babdbd58558212896d1a4272303a57bdb245c2bf1147185fb45640e70"
 
 [[package]]
 name = "cmake"
@@ -1140,9 +1140,9 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "4.1.2"
+version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a677b8922c94e01bdbb12126b0bc852f00447528dee1782229af9c720c3f348"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -1150,7 +1150,6 @@ dependencies = [
  "digest 0.10.7",
  "fiat-crypto",
  "group 0.13.0",
- "platforms",
  "rand_core",
  "rustc_version",
  "subtle",
@@ -1165,7 +1164,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -1184,7 +1183,7 @@ dependencies = [
 [[package]]
 name = "cycles-minting-canister"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f174aa82788f2dfc39b1cdb81fd19d691e77ac0b#f174aa82788f2dfc39b1cdb81fd19d691e77ac0b"
+source = "git+https://github.com/dfinity/ic?rev=cc4ea40e8571b80043013e4e74bd2b89844230c7#cc4ea40e8571b80043013e4e74bd2b89844230c7"
 dependencies = [
  "async-trait",
  "base64 0.13.1",
@@ -1300,7 +1299,7 @@ dependencies = [
  "asn1-rs",
  "displaydoc",
  "nom",
- "num-bigint 0.4.5",
+ "num-bigint 0.4.3",
  "num-traits",
  "rusticata-macros",
 ]
@@ -1327,21 +1326,21 @@ dependencies = [
 
 [[package]]
 name = "derive_more"
-version = "0.99.17"
+version = "0.99.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
+checksum = "5f33878137e4dafd7fa914ad4e259e18a4e8e532b9617a2d0150262bf53abfce"
 dependencies = [
  "convert_case 0.4.0",
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 1.0.109",
+ "syn 2.0.68",
 ]
 
 [[package]]
 name = "dfn_candid"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f174aa82788f2dfc39b1cdb81fd19d691e77ac0b#f174aa82788f2dfc39b1cdb81fd19d691e77ac0b"
+source = "git+https://github.com/dfinity/ic?rev=cc4ea40e8571b80043013e4e74bd2b89844230c7#cc4ea40e8571b80043013e4e74bd2b89844230c7"
 dependencies = [
  "candid",
  "dfn_core",
@@ -1353,7 +1352,7 @@ dependencies = [
 [[package]]
 name = "dfn_core"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f174aa82788f2dfc39b1cdb81fd19d691e77ac0b#f174aa82788f2dfc39b1cdb81fd19d691e77ac0b"
+source = "git+https://github.com/dfinity/ic?rev=cc4ea40e8571b80043013e4e74bd2b89844230c7#cc4ea40e8571b80043013e4e74bd2b89844230c7"
 dependencies = [
  "ic-base-types",
  "on_wire",
@@ -1362,7 +1361,7 @@ dependencies = [
 [[package]]
 name = "dfn_http"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f174aa82788f2dfc39b1cdb81fd19d691e77ac0b#f174aa82788f2dfc39b1cdb81fd19d691e77ac0b"
+source = "git+https://github.com/dfinity/ic?rev=cc4ea40e8571b80043013e4e74bd2b89844230c7#cc4ea40e8571b80043013e4e74bd2b89844230c7"
 dependencies = [
  "candid",
  "dfn_candid",
@@ -1374,7 +1373,7 @@ dependencies = [
 [[package]]
 name = "dfn_http_metrics"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f174aa82788f2dfc39b1cdb81fd19d691e77ac0b#f174aa82788f2dfc39b1cdb81fd19d691e77ac0b"
+source = "git+https://github.com/dfinity/ic?rev=cc4ea40e8571b80043013e4e74bd2b89844230c7#cc4ea40e8571b80043013e4e74bd2b89844230c7"
 dependencies = [
  "dfn_candid",
  "dfn_core",
@@ -1386,7 +1385,7 @@ dependencies = [
 [[package]]
 name = "dfn_protobuf"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f174aa82788f2dfc39b1cdb81fd19d691e77ac0b#f174aa82788f2dfc39b1cdb81fd19d691e77ac0b"
+source = "git+https://github.com/dfinity/ic?rev=cc4ea40e8571b80043013e4e74bd2b89844230c7#cc4ea40e8571b80043013e4e74bd2b89844230c7"
 dependencies = [
  "on_wire",
  "prost",
@@ -1395,15 +1394,16 @@ dependencies = [
 [[package]]
 name = "dfx-core"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/sdk?rev=cb67f24b7acb9aaa4609f38a34527a9436fb6b72#cb67f24b7acb9aaa4609f38a34527a9436fb6b72"
+source = "git+https://github.com/dfinity/sdk?rev=d8c1ede88d1978653d2e7d7005095fe38499e023#d8c1ede88d1978653d2e7d7005095fe38499e023"
 dependencies = [
  "aes-gcm",
  "argon2",
+ "backoff",
  "bip32",
  "byte-unit",
  "bytes",
  "candid",
- "clap 4.5.4",
+ "clap 4.5.8",
  "dialoguer",
  "directories-next",
  "dunce",
@@ -1413,17 +1413,18 @@ dependencies = [
  "humantime-serde",
  "ic-agent",
  "ic-identity-hsm",
- "ic-utils 0.35.0",
+ "ic-utils 0.36.0",
  "k256 0.11.6",
  "keyring",
  "lazy_static",
- "reqwest 0.12.4",
+ "reqwest 0.12.5",
  "ring 0.16.20",
  "schemars",
  "sec1 0.3.0",
  "semver",
  "serde",
  "serde_json",
+ "sha2 0.10.8",
  "slog",
  "tar",
  "tempfile",
@@ -1440,6 +1441,7 @@ dependencies = [
  "anyhow",
  "backoff",
  "candid",
+ "clap 4.5.8",
  "dfx-core",
  "flate2",
  "fn-error-context",
@@ -1532,13 +1534,13 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "487585f4d0c6655fe74905e2504d8ad6908e4db67f744eb140876906c2f3175d"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -1629,9 +1631,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.12.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dca9240753cf90908d7e4aac30f630662b02aebaa1b58a3cadabdb23385b58b"
+checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
 name = "elliptic-curve"
@@ -1743,9 +1745,9 @@ checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
 name = "event-listener"
-version = "4.0.3"
+version = "5.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b215c49b2b248c855fb73579eb1f4f26c38ffdc12973e20e07b91d78d5646e"
+checksum = "6032be9bd27023a771701cc49f9f053c751055f71efb2e0ae5c15809093675ba"
 dependencies = [
  "concurrent-queue",
  "parking",
@@ -1754,11 +1756,11 @@ dependencies = [
 
 [[package]]
 name = "event-listener-strategy"
-version = "0.4.0"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "958e4d70b6d5e81971bebec42271ec641e7ff4e170a6fa605f2b8a8b65cb97d3"
+checksum = "0f214dc438f977e6d4e3500aaa277f5ad94ca83fbbd9b1a15713ce2344ccc5a1"
 dependencies = [
- "event-listener 4.0.3",
+ "event-listener 5.3.1",
  "pin-project-lite",
 ]
 
@@ -1786,7 +1788,7 @@ checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
 [[package]]
 name = "fe-derive"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f174aa82788f2dfc39b1cdb81fd19d691e77ac0b#f174aa82788f2dfc39b1cdb81fd19d691e77ac0b"
+source = "git+https://github.com/dfinity/ic?rev=cc4ea40e8571b80043013e4e74bd2b89844230c7#cc4ea40e8571b80043013e4e74bd2b89844230c7"
 dependencies = [
  "hex",
  "num-bigint-dig",
@@ -1859,7 +1861,7 @@ checksum = "2cd66269887534af4b0c3e3337404591daa8dc8b9b2b3db71f9523beb4bafb41"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -1975,7 +1977,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -2243,6 +2245,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "home"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "http"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2287,12 +2298,12 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0475f8b2ac86659c21b64320d5d653f9efe42acd2a4e560073ec61a155a34f1d"
+checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
 dependencies = [
  "bytes",
- "futures-core",
+ "futures-util",
  "http 1.1.0",
  "http-body 1.0.0",
  "pin-project-lite",
@@ -2300,9 +2311,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.8.0"
+version = "1.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
+checksum = "0fcc0b4a115bf80b728eb8ea024ad5bd707b615bfed49e0665b6e0f86fd082d9"
 
 [[package]]
 name = "httpdate"
@@ -2328,9 +2339,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "0.14.28"
+version = "0.14.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf96e135eb83a2a8ddf766e426a841d8ddd7449d5f00d34ea02b41d2f19eef80"
+checksum = "f361cde2f109281a220d4307746cdfd5ee3f410da58a70377762396775634b33"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -2352,9 +2363,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.3.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe575dd17d0862a9a33781c8c4696a55c320909004a67a00fb286ba8b1bc496d"
+checksum = "c4fe55fb7a772d59a5ff1dfbff4fe0258d19b89fec4b233e75d35d5d2316badc"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -2376,7 +2387,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1788965e61b367cd03a62950836d5cd41560c3577d90e40e0819373194d1661c"
 dependencies = [
  "http 0.2.12",
- "hyper 0.14.28",
+ "hyper 0.14.29",
  "log",
  "rustls 0.20.9",
  "rustls-native-certs",
@@ -2393,7 +2404,7 @@ checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
 dependencies = [
  "futures-util",
  "http 0.2.12",
- "hyper 0.14.28",
+ "hyper 0.14.29",
  "rustls 0.21.12",
  "tokio",
  "tokio-rustls 0.24.1",
@@ -2401,19 +2412,20 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.26.0"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0bea761b46ae2b24eb4aef630d8d1c398157b6fc29e6350ecf090a0b70c952c"
+checksum = "5ee4be2c948921a1a5320b629c4193916ed787a7f7f293fd3f7f5a6c9de74155"
 dependencies = [
  "futures-util",
  "http 1.1.0",
- "hyper 1.3.1",
+ "hyper 1.4.0",
  "hyper-util",
- "rustls 0.22.4",
+ "rustls 0.23.10",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.25.0",
+ "tokio-rustls 0.26.0",
  "tower-service",
+ "webpki-roots 0.26.3",
 ]
 
 [[package]]
@@ -2423,7 +2435,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
 dependencies = [
  "bytes",
- "hyper 0.14.28",
+ "hyper 0.14.29",
  "native-tls",
  "tokio",
  "tokio-native-tls",
@@ -2431,16 +2443,16 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b875924a60b96e5d7b9ae7b066540b1dd1cbd90d1828f54c92e02a283351c56"
+checksum = "3ab92f4f49ee4fb4f997c784b7a2e0fa70050211e0b6a287f898c3c9785ca956"
 dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
  "http 1.1.0",
  "http-body 1.0.0",
- "hyper 1.3.1",
+ "hyper 1.4.0",
  "pin-project-lite",
  "socket2 0.5.7",
  "tokio",
@@ -2474,10 +2486,10 @@ dependencies = [
 
 [[package]]
 name = "ic-agent"
-version = "0.35.0"
-source = "git+https://github.com/dfinity/agent-rs?rev=8273d321e9a09fd8373bd4e38b0676ec6ad9c260#8273d321e9a09fd8373bd4e38b0676ec6ad9c260"
+version = "0.36.0"
+source = "git+https://github.com/dfinity/agent-rs?rev=be929fd7967249c879f48f2f494cbfc5805a7d98#be929fd7967249c879f48f2f494cbfc5805a7d98"
 dependencies = [
- "async-lock 3.3.0",
+ "async-lock 3.4.0",
  "backoff",
  "cached 0.46.1",
  "candid",
@@ -2496,7 +2508,7 @@ dependencies = [
  "pkcs8 0.10.2",
  "rand",
  "rangemap",
- "reqwest 0.12.4",
+ "reqwest 0.12.5",
  "ring 0.17.8",
  "rustls-webpki 0.101.7",
  "sec1 0.7.3",
@@ -2515,7 +2527,7 @@ dependencies = [
 [[package]]
 name = "ic-base-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f174aa82788f2dfc39b1cdb81fd19d691e77ac0b#f174aa82788f2dfc39b1cdb81fd19d691e77ac0b"
+source = "git+https://github.com/dfinity/ic?rev=cc4ea40e8571b80043013e4e74bd2b89844230c7#cc4ea40e8571b80043013e4e74bd2b89844230c7"
 dependencies = [
  "byte-unit",
  "bytes",
@@ -2530,9 +2542,9 @@ dependencies = [
 
 [[package]]
 name = "ic-btc-interface"
-version = "0.2.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c2d1eedb5fcd02b6aab21fa6e0989ae560505e510bf221af9ab57bffbc83ac"
+checksum = "b0152e14e697b0e988dbfdcb3f7e352d1c76a65b7d2d75c5d76bad22c3aca10d"
 dependencies = [
  "candid",
  "serde",
@@ -2542,7 +2554,7 @@ dependencies = [
 [[package]]
 name = "ic-btc-types-internal"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f174aa82788f2dfc39b1cdb81fd19d691e77ac0b#f174aa82788f2dfc39b1cdb81fd19d691e77ac0b"
+source = "git+https://github.com/dfinity/ic?rev=cc4ea40e8571b80043013e4e74bd2b89844230c7#cc4ea40e8571b80043013e4e74bd2b89844230c7"
 dependencies = [
  "candid",
  "ic-btc-interface",
@@ -2555,7 +2567,7 @@ dependencies = [
 [[package]]
 name = "ic-canister-client-sender"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f174aa82788f2dfc39b1cdb81fd19d691e77ac0b#f174aa82788f2dfc39b1cdb81fd19d691e77ac0b"
+source = "git+https://github.com/dfinity/ic?rev=cc4ea40e8571b80043013e4e74bd2b89844230c7#cc4ea40e8571b80043013e4e74bd2b89844230c7"
 dependencies = [
  "ic-base-types",
  "ic-crypto-ecdsa-secp256k1",
@@ -2568,7 +2580,7 @@ dependencies = [
 [[package]]
 name = "ic-canister-log"
 version = "0.2.0"
-source = "git+https://github.com/dfinity/ic?rev=f174aa82788f2dfc39b1cdb81fd19d691e77ac0b#f174aa82788f2dfc39b1cdb81fd19d691e77ac0b"
+source = "git+https://github.com/dfinity/ic?rev=cc4ea40e8571b80043013e4e74bd2b89844230c7#cc4ea40e8571b80043013e4e74bd2b89844230c7"
 dependencies = [
  "serde",
 ]
@@ -2576,7 +2588,7 @@ dependencies = [
 [[package]]
 name = "ic-canister-profiler"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f174aa82788f2dfc39b1cdb81fd19d691e77ac0b#f174aa82788f2dfc39b1cdb81fd19d691e77ac0b"
+source = "git+https://github.com/dfinity/ic?rev=cc4ea40e8571b80043013e4e74bd2b89844230c7#cc4ea40e8571b80043013e4e74bd2b89844230c7"
 dependencies = [
  "ic-metrics-encoder",
  "ic0 0.18.11",
@@ -2585,7 +2597,7 @@ dependencies = [
 [[package]]
 name = "ic-canisters-http-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f174aa82788f2dfc39b1cdb81fd19d691e77ac0b#f174aa82788f2dfc39b1cdb81fd19d691e77ac0b"
+source = "git+https://github.com/dfinity/ic?rev=cc4ea40e8571b80043013e4e74bd2b89844230c7#cc4ea40e8571b80043013e4e74bd2b89844230c7"
 dependencies = [
  "candid",
  "serde",
@@ -2673,16 +2685,16 @@ dependencies = [
 [[package]]
 name = "ic-constants"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f174aa82788f2dfc39b1cdb81fd19d691e77ac0b#f174aa82788f2dfc39b1cdb81fd19d691e77ac0b"
+source = "git+https://github.com/dfinity/ic?rev=cc4ea40e8571b80043013e4e74bd2b89844230c7#cc4ea40e8571b80043013e4e74bd2b89844230c7"
 
 [[package]]
 name = "ic-crypto-ecdsa-secp256k1"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f174aa82788f2dfc39b1cdb81fd19d691e77ac0b#f174aa82788f2dfc39b1cdb81fd19d691e77ac0b"
+source = "git+https://github.com/dfinity/ic?rev=cc4ea40e8571b80043013e4e74bd2b89844230c7#cc4ea40e8571b80043013e4e74bd2b89844230c7"
 dependencies = [
  "k256 0.13.3",
  "lazy_static",
- "num-bigint 0.4.5",
+ "num-bigint 0.4.3",
  "pem 1.1.1",
  "rand",
  "simple_asn1",
@@ -2692,7 +2704,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-ed25519"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f174aa82788f2dfc39b1cdb81fd19d691e77ac0b#f174aa82788f2dfc39b1cdb81fd19d691e77ac0b"
+source = "git+https://github.com/dfinity/ic?rev=cc4ea40e8571b80043013e4e74bd2b89844230c7#cc4ea40e8571b80043013e4e74bd2b89844230c7"
 dependencies = [
  "curve25519-dalek",
  "ed25519-dalek",
@@ -2706,7 +2718,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-getrandom-for-wasm"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f174aa82788f2dfc39b1cdb81fd19d691e77ac0b#f174aa82788f2dfc39b1cdb81fd19d691e77ac0b"
+source = "git+https://github.com/dfinity/ic?rev=cc4ea40e8571b80043013e4e74bd2b89844230c7#cc4ea40e8571b80043013e4e74bd2b89844230c7"
 dependencies = [
  "getrandom",
 ]
@@ -2714,7 +2726,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-basic-sig-der-utils"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f174aa82788f2dfc39b1cdb81fd19d691e77ac0b#f174aa82788f2dfc39b1cdb81fd19d691e77ac0b"
+source = "git+https://github.com/dfinity/ic?rev=cc4ea40e8571b80043013e4e74bd2b89844230c7#cc4ea40e8571b80043013e4e74bd2b89844230c7"
 dependencies = [
  "hex",
  "ic-types",
@@ -2724,12 +2736,13 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-basic-sig-ed25519"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f174aa82788f2dfc39b1cdb81fd19d691e77ac0b#f174aa82788f2dfc39b1cdb81fd19d691e77ac0b"
+source = "git+https://github.com/dfinity/ic?rev=cc4ea40e8571b80043013e4e74bd2b89844230c7#cc4ea40e8571b80043013e4e74bd2b89844230c7"
 dependencies = [
  "base64 0.13.1",
  "curve25519-dalek",
  "ed25519-consensus",
  "hex",
+ "ic-crypto-ed25519",
  "ic-crypto-internal-basic-sig-der-utils",
  "ic-crypto-internal-seed",
  "ic-crypto-internal-types",
@@ -2746,17 +2759,17 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-bls12-381-type"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f174aa82788f2dfc39b1cdb81fd19d691e77ac0b#f174aa82788f2dfc39b1cdb81fd19d691e77ac0b"
+source = "git+https://github.com/dfinity/ic?rev=cc4ea40e8571b80043013e4e74bd2b89844230c7#cc4ea40e8571b80043013e4e74bd2b89844230c7"
 dependencies = [
  "hex",
  "ic_bls12_381",
- "itertools",
+ "itertools 0.12.1",
  "lazy_static",
- "pairing",
+ "pairing 0.23.0",
  "paste",
  "rand",
  "rand_chacha",
- "sha2 0.9.9",
+ "sha2 0.10.8",
  "subtle",
  "zeroize",
 ]
@@ -2764,7 +2777,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-hmac"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f174aa82788f2dfc39b1cdb81fd19d691e77ac0b#f174aa82788f2dfc39b1cdb81fd19d691e77ac0b"
+source = "git+https://github.com/dfinity/ic?rev=cc4ea40e8571b80043013e4e74bd2b89844230c7#cc4ea40e8571b80043013e4e74bd2b89844230c7"
 dependencies = [
  "ic-crypto-internal-sha2",
 ]
@@ -2772,7 +2785,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-multi-sig-bls12381"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f174aa82788f2dfc39b1cdb81fd19d691e77ac0b#f174aa82788f2dfc39b1cdb81fd19d691e77ac0b"
+source = "git+https://github.com/dfinity/ic?rev=cc4ea40e8571b80043013e4e74bd2b89844230c7#cc4ea40e8571b80043013e4e74bd2b89844230c7"
 dependencies = [
  "base64 0.13.1",
  "hex",
@@ -2791,7 +2804,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-seed"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f174aa82788f2dfc39b1cdb81fd19d691e77ac0b#f174aa82788f2dfc39b1cdb81fd19d691e77ac0b"
+source = "git+https://github.com/dfinity/ic?rev=cc4ea40e8571b80043013e4e74bd2b89844230c7#cc4ea40e8571b80043013e4e74bd2b89844230c7"
 dependencies = [
  "hex",
  "ic-crypto-sha2",
@@ -2804,7 +2817,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-sha2"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f174aa82788f2dfc39b1cdb81fd19d691e77ac0b#f174aa82788f2dfc39b1cdb81fd19d691e77ac0b"
+source = "git+https://github.com/dfinity/ic?rev=cc4ea40e8571b80043013e4e74bd2b89844230c7#cc4ea40e8571b80043013e4e74bd2b89844230c7"
 dependencies = [
  "sha2 0.10.8",
 ]
@@ -2812,7 +2825,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-threshold-sig-bls12381"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f174aa82788f2dfc39b1cdb81fd19d691e77ac0b#f174aa82788f2dfc39b1cdb81fd19d691e77ac0b"
+source = "git+https://github.com/dfinity/ic?rev=cc4ea40e8571b80043013e4e74bd2b89844230c7#cc4ea40e8571b80043013e4e74bd2b89844230c7"
 dependencies = [
  "base64 0.13.1",
  "cached 0.49.3",
@@ -2830,7 +2843,7 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_cbor",
- "strum_macros 0.26.2",
+ "strum_macros 0.26.4",
  "subtle",
  "zeroize",
 ]
@@ -2838,7 +2851,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-threshold-sig-ecdsa"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f174aa82788f2dfc39b1cdb81fd19d691e77ac0b#f174aa82788f2dfc39b1cdb81fd19d691e77ac0b"
+source = "git+https://github.com/dfinity/ic?rev=cc4ea40e8571b80043013e4e74bd2b89844230c7#cc4ea40e8571b80043013e4e74bd2b89844230c7"
 dependencies = [
  "curve25519-dalek",
  "fe-derive",
@@ -2859,8 +2872,8 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_cbor",
- "strum 0.26.2",
- "strum_macros 0.26.2",
+ "strum 0.26.3",
+ "strum_macros 0.26.4",
  "subtle",
  "zeroize",
 ]
@@ -2868,7 +2881,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f174aa82788f2dfc39b1cdb81fd19d691e77ac0b#f174aa82788f2dfc39b1cdb81fd19d691e77ac0b"
+source = "git+https://github.com/dfinity/ic?rev=cc4ea40e8571b80043013e4e74bd2b89844230c7#cc4ea40e8571b80043013e4e74bd2b89844230c7"
 dependencies = [
  "arrayvec 0.7.4",
  "hex",
@@ -2876,8 +2889,8 @@ dependencies = [
  "phantom_newtype",
  "serde",
  "serde_cbor",
- "strum 0.26.2",
- "strum_macros 0.26.2",
+ "strum 0.26.3",
+ "strum_macros 0.26.4",
  "thiserror",
  "zeroize",
 ]
@@ -2885,7 +2898,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-node-key-validation"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f174aa82788f2dfc39b1cdb81fd19d691e77ac0b#f174aa82788f2dfc39b1cdb81fd19d691e77ac0b"
+source = "git+https://github.com/dfinity/ic?rev=cc4ea40e8571b80043013e4e74bd2b89844230c7#cc4ea40e8571b80043013e4e74bd2b89844230c7"
 dependencies = [
  "hex",
  "ic-base-types",
@@ -2903,7 +2916,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-secrets-containers"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f174aa82788f2dfc39b1cdb81fd19d691e77ac0b#f174aa82788f2dfc39b1cdb81fd19d691e77ac0b"
+source = "git+https://github.com/dfinity/ic?rev=cc4ea40e8571b80043013e4e74bd2b89844230c7#cc4ea40e8571b80043013e4e74bd2b89844230c7"
 dependencies = [
  "serde",
  "zeroize",
@@ -2912,7 +2925,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-sha2"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f174aa82788f2dfc39b1cdb81fd19d691e77ac0b#f174aa82788f2dfc39b1cdb81fd19d691e77ac0b"
+source = "git+https://github.com/dfinity/ic?rev=cc4ea40e8571b80043013e4e74bd2b89844230c7#cc4ea40e8571b80043013e4e74bd2b89844230c7"
 dependencies = [
  "ic-crypto-internal-sha2",
 ]
@@ -2920,7 +2933,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-tls-cert-validation"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f174aa82788f2dfc39b1cdb81fd19d691e77ac0b#f174aa82788f2dfc39b1cdb81fd19d691e77ac0b"
+source = "git+https://github.com/dfinity/ic?rev=cc4ea40e8571b80043013e4e74bd2b89844230c7#cc4ea40e8571b80043013e4e74bd2b89844230c7"
 dependencies = [
  "hex",
  "ic-crypto-internal-basic-sig-ed25519",
@@ -2933,7 +2946,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-tree-hash"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f174aa82788f2dfc39b1cdb81fd19d691e77ac0b#f174aa82788f2dfc39b1cdb81fd19d691e77ac0b"
+source = "git+https://github.com/dfinity/ic?rev=cc4ea40e8571b80043013e4e74bd2b89844230c7#cc4ea40e8571b80043013e4e74bd2b89844230c7"
 dependencies = [
  "ic-crypto-internal-types",
  "ic-crypto-sha2",
@@ -2946,7 +2959,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-utils-basic-sig"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f174aa82788f2dfc39b1cdb81fd19d691e77ac0b#f174aa82788f2dfc39b1cdb81fd19d691e77ac0b"
+source = "git+https://github.com/dfinity/ic?rev=cc4ea40e8571b80043013e4e74bd2b89844230c7#cc4ea40e8571b80043013e4e74bd2b89844230c7"
 dependencies = [
  "ic-base-types",
  "ic-crypto-ed25519",
@@ -2956,7 +2969,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-utils-ni-dkg"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=f174aa82788f2dfc39b1cdb81fd19d691e77ac0b#f174aa82788f2dfc39b1cdb81fd19d691e77ac0b"
+source = "git+https://github.com/dfinity/ic?rev=cc4ea40e8571b80043013e4e74bd2b89844230c7#cc4ea40e8571b80043013e4e74bd2b89844230c7"
 dependencies = [
  "ic-crypto-internal-types",
  "ic-protobuf",
@@ -2966,19 +2979,19 @@ dependencies = [
 [[package]]
 name = "ic-error-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f174aa82788f2dfc39b1cdb81fd19d691e77ac0b#f174aa82788f2dfc39b1cdb81fd19d691e77ac0b"
+source = "git+https://github.com/dfinity/ic?rev=cc4ea40e8571b80043013e4e74bd2b89844230c7#cc4ea40e8571b80043013e4e74bd2b89844230c7"
 dependencies = [
  "ic-protobuf",
  "ic-utils 0.9.0",
  "serde",
- "strum 0.26.2",
- "strum_macros 0.26.2",
+ "strum 0.26.3",
+ "strum_macros 0.26.4",
 ]
 
 [[package]]
 name = "ic-icp-index"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f174aa82788f2dfc39b1cdb81fd19d691e77ac0b#f174aa82788f2dfc39b1cdb81fd19d691e77ac0b"
+source = "git+https://github.com/dfinity/ic?rev=cc4ea40e8571b80043013e4e74bd2b89844230c7#cc4ea40e8571b80043013e4e74bd2b89844230c7"
 dependencies = [
  "candid",
  "ciborium",
@@ -3006,7 +3019,7 @@ dependencies = [
 [[package]]
 name = "ic-icrc1"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f174aa82788f2dfc39b1cdb81fd19d691e77ac0b#f174aa82788f2dfc39b1cdb81fd19d691e77ac0b"
+source = "git+https://github.com/dfinity/ic?rev=cc4ea40e8571b80043013e4e74bd2b89844230c7#cc4ea40e8571b80043013e4e74bd2b89844230c7"
 dependencies = [
  "candid",
  "ciborium",
@@ -3017,7 +3030,7 @@ dependencies = [
  "ic-ledger-core",
  "ic-ledger-hash-of",
  "icrc-ledger-types",
- "num-bigint 0.4.5",
+ "num-bigint 0.4.3",
  "num-traits",
  "serde",
  "serde_bytes",
@@ -3028,7 +3041,7 @@ dependencies = [
 [[package]]
 name = "ic-icrc1-index-ng"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f174aa82788f2dfc39b1cdb81fd19d691e77ac0b#f174aa82788f2dfc39b1cdb81fd19d691e77ac0b"
+source = "git+https://github.com/dfinity/ic?rev=cc4ea40e8571b80043013e4e74bd2b89844230c7#cc4ea40e8571b80043013e4e74bd2b89844230c7"
 dependencies = [
  "candid",
  "ciborium",
@@ -3056,7 +3069,7 @@ dependencies = [
 [[package]]
 name = "ic-icrc1-ledger"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f174aa82788f2dfc39b1cdb81fd19d691e77ac0b#f174aa82788f2dfc39b1cdb81fd19d691e77ac0b"
+source = "git+https://github.com/dfinity/ic?rev=cc4ea40e8571b80043013e4e74bd2b89844230c7#cc4ea40e8571b80043013e4e74bd2b89844230c7"
 dependencies = [
  "async-trait",
  "candid",
@@ -3084,7 +3097,7 @@ dependencies = [
 [[package]]
 name = "ic-icrc1-tokens-u64"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=f174aa82788f2dfc39b1cdb81fd19d691e77ac0b#f174aa82788f2dfc39b1cdb81fd19d691e77ac0b"
+source = "git+https://github.com/dfinity/ic?rev=cc4ea40e8571b80043013e4e74bd2b89844230c7#cc4ea40e8571b80043013e4e74bd2b89844230c7"
 dependencies = [
  "candid",
  "ic-ledger-core",
@@ -3095,8 +3108,8 @@ dependencies = [
 
 [[package]]
 name = "ic-identity-hsm"
-version = "0.35.0"
-source = "git+https://github.com/dfinity/agent-rs?rev=8273d321e9a09fd8373bd4e38b0676ec6ad9c260#8273d321e9a09fd8373bd4e38b0676ec6ad9c260"
+version = "0.36.0"
+source = "git+https://github.com/dfinity/agent-rs?rev=be929fd7967249c879f48f2f494cbfc5805a7d98#be929fd7967249c879f48f2f494cbfc5805a7d98"
 dependencies = [
  "hex",
  "ic-agent",
@@ -3109,7 +3122,7 @@ dependencies = [
 [[package]]
 name = "ic-ledger-canister-core"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f174aa82788f2dfc39b1cdb81fd19d691e77ac0b#f174aa82788f2dfc39b1cdb81fd19d691e77ac0b"
+source = "git+https://github.com/dfinity/ic?rev=cc4ea40e8571b80043013e4e74bd2b89844230c7#cc4ea40e8571b80043013e4e74bd2b89844230c7"
 dependencies = [
  "async-trait",
  "candid",
@@ -3127,7 +3140,7 @@ dependencies = [
 [[package]]
 name = "ic-ledger-core"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f174aa82788f2dfc39b1cdb81fd19d691e77ac0b#f174aa82788f2dfc39b1cdb81fd19d691e77ac0b"
+source = "git+https://github.com/dfinity/ic?rev=cc4ea40e8571b80043013e4e74bd2b89844230c7#cc4ea40e8571b80043013e4e74bd2b89844230c7"
 dependencies = [
  "candid",
  "ic-ledger-hash-of",
@@ -3139,7 +3152,7 @@ dependencies = [
 [[package]]
 name = "ic-ledger-hash-of"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=f174aa82788f2dfc39b1cdb81fd19d691e77ac0b#f174aa82788f2dfc39b1cdb81fd19d691e77ac0b"
+source = "git+https://github.com/dfinity/ic?rev=cc4ea40e8571b80043013e4e74bd2b89844230c7#cc4ea40e8571b80043013e4e74bd2b89844230c7"
 dependencies = [
  "candid",
  "hex",
@@ -3149,7 +3162,7 @@ dependencies = [
 [[package]]
 name = "ic-management-canister-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f174aa82788f2dfc39b1cdb81fd19d691e77ac0b#f174aa82788f2dfc39b1cdb81fd19d691e77ac0b"
+source = "git+https://github.com/dfinity/ic?rev=cc4ea40e8571b80043013e4e74bd2b89844230c7#cc4ea40e8571b80043013e4e74bd2b89844230c7"
 dependencies = [
  "candid",
  "ic-base-types",
@@ -3161,8 +3174,8 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_cbor",
- "strum 0.26.2",
- "strum_macros 0.26.2",
+ "strum 0.26.3",
+ "strum_macros 0.26.4",
 ]
 
 [[package]]
@@ -3174,7 +3187,7 @@ checksum = "8b5c7628eac357aecda461130f8074468be5aa4d258a002032d82d817f79f1f8"
 [[package]]
 name = "ic-nervous-system-clients"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=f174aa82788f2dfc39b1cdb81fd19d691e77ac0b#f174aa82788f2dfc39b1cdb81fd19d691e77ac0b"
+source = "git+https://github.com/dfinity/ic?rev=cc4ea40e8571b80043013e4e74bd2b89844230c7#cc4ea40e8571b80043013e4e74bd2b89844230c7"
 dependencies = [
  "async-trait",
  "candid",
@@ -3197,12 +3210,12 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-collections-union-multi-map"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=f174aa82788f2dfc39b1cdb81fd19d691e77ac0b#f174aa82788f2dfc39b1cdb81fd19d691e77ac0b"
+source = "git+https://github.com/dfinity/ic?rev=cc4ea40e8571b80043013e4e74bd2b89844230c7#cc4ea40e8571b80043013e4e74bd2b89844230c7"
 
 [[package]]
 name = "ic-nervous-system-common"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f174aa82788f2dfc39b1cdb81fd19d691e77ac0b#f174aa82788f2dfc39b1cdb81fd19d691e77ac0b"
+source = "git+https://github.com/dfinity/ic?rev=cc4ea40e8571b80043013e4e74bd2b89844230c7#cc4ea40e8571b80043013e4e74bd2b89844230c7"
 dependencies = [
  "async-trait",
  "base64 0.13.1",
@@ -3238,12 +3251,12 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-common-build-metadata"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f174aa82788f2dfc39b1cdb81fd19d691e77ac0b#f174aa82788f2dfc39b1cdb81fd19d691e77ac0b"
+source = "git+https://github.com/dfinity/ic?rev=cc4ea40e8571b80043013e4e74bd2b89844230c7#cc4ea40e8571b80043013e4e74bd2b89844230c7"
 
 [[package]]
 name = "ic-nervous-system-common-test-keys"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f174aa82788f2dfc39b1cdb81fd19d691e77ac0b#f174aa82788f2dfc39b1cdb81fd19d691e77ac0b"
+source = "git+https://github.com/dfinity/ic?rev=cc4ea40e8571b80043013e4e74bd2b89844230c7#cc4ea40e8571b80043013e4e74bd2b89844230c7"
 dependencies = [
  "ic-base-types",
  "ic-canister-client-sender",
@@ -3256,7 +3269,7 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-governance"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=f174aa82788f2dfc39b1cdb81fd19d691e77ac0b#f174aa82788f2dfc39b1cdb81fd19d691e77ac0b"
+source = "git+https://github.com/dfinity/ic?rev=cc4ea40e8571b80043013e4e74bd2b89844230c7#cc4ea40e8571b80043013e4e74bd2b89844230c7"
 dependencies = [
  "ic-base-types",
  "ic-stable-structures",
@@ -3268,7 +3281,7 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-humanize"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f174aa82788f2dfc39b1cdb81fd19d691e77ac0b#f174aa82788f2dfc39b1cdb81fd19d691e77ac0b"
+source = "git+https://github.com/dfinity/ic?rev=cc4ea40e8571b80043013e4e74bd2b89844230c7#cc4ea40e8571b80043013e4e74bd2b89844230c7"
 dependencies = [
  "humantime",
  "ic-nervous-system-proto",
@@ -3280,12 +3293,12 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-lock"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=f174aa82788f2dfc39b1cdb81fd19d691e77ac0b#f174aa82788f2dfc39b1cdb81fd19d691e77ac0b"
+source = "git+https://github.com/dfinity/ic?rev=cc4ea40e8571b80043013e4e74bd2b89844230c7#cc4ea40e8571b80043013e4e74bd2b89844230c7"
 
 [[package]]
 name = "ic-nervous-system-proto"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f174aa82788f2dfc39b1cdb81fd19d691e77ac0b#f174aa82788f2dfc39b1cdb81fd19d691e77ac0b"
+source = "git+https://github.com/dfinity/ic?rev=cc4ea40e8571b80043013e4e74bd2b89844230c7#cc4ea40e8571b80043013e4e74bd2b89844230c7"
 dependencies = [
  "candid",
  "comparable",
@@ -3298,7 +3311,7 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-proxied-canister-calls-tracker"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f174aa82788f2dfc39b1cdb81fd19d691e77ac0b#f174aa82788f2dfc39b1cdb81fd19d691e77ac0b"
+source = "git+https://github.com/dfinity/ic?rev=cc4ea40e8571b80043013e4e74bd2b89844230c7#cc4ea40e8571b80043013e4e74bd2b89844230c7"
 dependencies = [
  "ic-base-types",
 ]
@@ -3306,7 +3319,7 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-root"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f174aa82788f2dfc39b1cdb81fd19d691e77ac0b#f174aa82788f2dfc39b1cdb81fd19d691e77ac0b"
+source = "git+https://github.com/dfinity/ic?rev=cc4ea40e8571b80043013e4e74bd2b89844230c7#cc4ea40e8571b80043013e4e74bd2b89844230c7"
 dependencies = [
  "candid",
  "dfn_core",
@@ -3322,7 +3335,7 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-runtime"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f174aa82788f2dfc39b1cdb81fd19d691e77ac0b#f174aa82788f2dfc39b1cdb81fd19d691e77ac0b"
+source = "git+https://github.com/dfinity/ic?rev=cc4ea40e8571b80043013e4e74bd2b89844230c7#cc4ea40e8571b80043013e4e74bd2b89844230c7"
 dependencies = [
  "async-trait",
  "candid",
@@ -3335,12 +3348,12 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-string"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=f174aa82788f2dfc39b1cdb81fd19d691e77ac0b#f174aa82788f2dfc39b1cdb81fd19d691e77ac0b"
+source = "git+https://github.com/dfinity/ic?rev=cc4ea40e8571b80043013e4e74bd2b89844230c7#cc4ea40e8571b80043013e4e74bd2b89844230c7"
 
 [[package]]
 name = "ic-neurons-fund"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=f174aa82788f2dfc39b1cdb81fd19d691e77ac0b#f174aa82788f2dfc39b1cdb81fd19d691e77ac0b"
+source = "git+https://github.com/dfinity/ic?rev=cc4ea40e8571b80043013e4e74bd2b89844230c7#cc4ea40e8571b80043013e4e74bd2b89844230c7"
 dependencies = [
  "ic-nervous-system-common",
  "lazy_static",
@@ -3353,7 +3366,7 @@ dependencies = [
 [[package]]
 name = "ic-nns-common"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f174aa82788f2dfc39b1cdb81fd19d691e77ac0b#f174aa82788f2dfc39b1cdb81fd19d691e77ac0b"
+source = "git+https://github.com/dfinity/ic?rev=cc4ea40e8571b80043013e4e74bd2b89844230c7#cc4ea40e8571b80043013e4e74bd2b89844230c7"
 dependencies = [
  "candid",
  "comparable",
@@ -3379,7 +3392,7 @@ dependencies = [
 [[package]]
 name = "ic-nns-constants"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f174aa82788f2dfc39b1cdb81fd19d691e77ac0b#f174aa82788f2dfc39b1cdb81fd19d691e77ac0b"
+source = "git+https://github.com/dfinity/ic?rev=cc4ea40e8571b80043013e4e74bd2b89844230c7#cc4ea40e8571b80043013e4e74bd2b89844230c7"
 dependencies = [
  "ic-base-types",
  "maplit",
@@ -3388,7 +3401,7 @@ dependencies = [
 [[package]]
 name = "ic-nns-governance"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f174aa82788f2dfc39b1cdb81fd19d691e77ac0b#f174aa82788f2dfc39b1cdb81fd19d691e77ac0b"
+source = "git+https://github.com/dfinity/ic?rev=cc4ea40e8571b80043013e4e74bd2b89844230c7#cc4ea40e8571b80043013e4e74bd2b89844230c7"
 dependencies = [
  "async-trait",
  "build-info",
@@ -3428,7 +3441,7 @@ dependencies = [
  "ic-stable-structures",
  "ic-types",
  "icp-ledger",
- "itertools",
+ "itertools 0.12.1",
  "lazy_static",
  "maplit",
  "mockall",
@@ -3444,19 +3457,19 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_json",
- "strum 0.26.2",
- "strum_macros 0.26.2",
+ "strum 0.26.3",
+ "strum_macros 0.26.4",
 ]
 
 [[package]]
 name = "ic-nns-gtc-accounts"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f174aa82788f2dfc39b1cdb81fd19d691e77ac0b#f174aa82788f2dfc39b1cdb81fd19d691e77ac0b"
+source = "git+https://github.com/dfinity/ic?rev=cc4ea40e8571b80043013e4e74bd2b89844230c7#cc4ea40e8571b80043013e4e74bd2b89844230c7"
 
 [[package]]
 name = "ic-nns-handler-root-interface"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=f174aa82788f2dfc39b1cdb81fd19d691e77ac0b#f174aa82788f2dfc39b1cdb81fd19d691e77ac0b"
+source = "git+https://github.com/dfinity/ic?rev=cc4ea40e8571b80043013e4e74bd2b89844230c7#cc4ea40e8571b80043013e4e74bd2b89844230c7"
 dependencies = [
  "async-trait",
  "candid",
@@ -3471,12 +3484,11 @@ dependencies = [
 [[package]]
 name = "ic-protobuf"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f174aa82788f2dfc39b1cdb81fd19d691e77ac0b#f174aa82788f2dfc39b1cdb81fd19d691e77ac0b"
+source = "git+https://github.com/dfinity/ic?rev=cc4ea40e8571b80043013e4e74bd2b89844230c7#cc4ea40e8571b80043013e4e74bd2b89844230c7"
 dependencies = [
  "bincode",
  "candid",
  "erased-serde",
- "maplit",
  "prost",
  "serde",
  "serde_json",
@@ -3486,7 +3498,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-keys"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f174aa82788f2dfc39b1cdb81fd19d691e77ac0b#f174aa82788f2dfc39b1cdb81fd19d691e77ac0b"
+source = "git+https://github.com/dfinity/ic?rev=cc4ea40e8571b80043013e4e74bd2b89844230c7#cc4ea40e8571b80043013e4e74bd2b89844230c7"
 dependencies = [
  "candid",
  "ic-base-types",
@@ -3498,7 +3510,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-routing-table"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f174aa82788f2dfc39b1cdb81fd19d691e77ac0b#f174aa82788f2dfc39b1cdb81fd19d691e77ac0b"
+source = "git+https://github.com/dfinity/ic?rev=cc4ea40e8571b80043013e4e74bd2b89844230c7#cc4ea40e8571b80043013e4e74bd2b89844230c7"
 dependencies = [
  "candid",
  "ic-base-types",
@@ -3509,7 +3521,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-subnet-features"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f174aa82788f2dfc39b1cdb81fd19d691e77ac0b#f174aa82788f2dfc39b1cdb81fd19d691e77ac0b"
+source = "git+https://github.com/dfinity/ic?rev=cc4ea40e8571b80043013e4e74bd2b89844230c7#cc4ea40e8571b80043013e4e74bd2b89844230c7"
 dependencies = [
  "candid",
  "ic-management-canister-types",
@@ -3520,19 +3532,19 @@ dependencies = [
 [[package]]
 name = "ic-registry-subnet-type"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f174aa82788f2dfc39b1cdb81fd19d691e77ac0b#f174aa82788f2dfc39b1cdb81fd19d691e77ac0b"
+source = "git+https://github.com/dfinity/ic?rev=cc4ea40e8571b80043013e4e74bd2b89844230c7#cc4ea40e8571b80043013e4e74bd2b89844230c7"
 dependencies = [
  "candid",
  "ic-protobuf",
  "serde",
- "strum 0.26.2",
- "strum_macros 0.26.2",
+ "strum 0.26.3",
+ "strum_macros 0.26.4",
 ]
 
 [[package]]
 name = "ic-registry-transport"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f174aa82788f2dfc39b1cdb81fd19d691e77ac0b#f174aa82788f2dfc39b1cdb81fd19d691e77ac0b"
+source = "git+https://github.com/dfinity/ic?rev=cc4ea40e8571b80043013e4e74bd2b89844230c7#cc4ea40e8571b80043013e4e74bd2b89844230c7"
 dependencies = [
  "candid",
  "ic-base-types",
@@ -3544,12 +3556,12 @@ dependencies = [
 [[package]]
 name = "ic-sns-cli"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f174aa82788f2dfc39b1cdb81fd19d691e77ac0b#f174aa82788f2dfc39b1cdb81fd19d691e77ac0b"
+source = "git+https://github.com/dfinity/ic?rev=cc4ea40e8571b80043013e4e74bd2b89844230c7#cc4ea40e8571b80043013e4e74bd2b89844230c7"
 dependencies = [
  "anyhow",
  "base64 0.13.1",
  "candid",
- "clap 4.5.4",
+ "clap 4.5.8",
  "hex",
  "ic-base-types",
  "ic-crypto-sha2",
@@ -3564,7 +3576,7 @@ dependencies = [
  "ic-sns-init",
  "ic-sns-root",
  "ic-sns-wasm",
- "itertools",
+ "itertools 0.12.1",
  "json-patch",
  "pretty_assertions",
  "serde",
@@ -3577,7 +3589,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-governance"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f174aa82788f2dfc39b1cdb81fd19d691e77ac0b#f174aa82788f2dfc39b1cdb81fd19d691e77ac0b"
+source = "git+https://github.com/dfinity/ic?rev=cc4ea40e8571b80043013e4e74bd2b89844230c7#cc4ea40e8571b80043013e4e74bd2b89844230c7"
 dependencies = [
  "async-trait",
  "base64 0.13.1",
@@ -3627,14 +3639,14 @@ dependencies = [
  "rust_decimal_macros",
  "serde",
  "serde_bytes",
- "strum 0.26.2",
- "strum_macros 0.26.2",
+ "strum 0.26.3",
+ "strum_macros 0.26.4",
 ]
 
 [[package]]
 name = "ic-sns-governance-proposal-criticality"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=f174aa82788f2dfc39b1cdb81fd19d691e77ac0b#f174aa82788f2dfc39b1cdb81fd19d691e77ac0b"
+source = "git+https://github.com/dfinity/ic?rev=cc4ea40e8571b80043013e4e74bd2b89844230c7#cc4ea40e8571b80043013e4e74bd2b89844230c7"
 dependencies = [
  "ic-nervous-system-proto",
 ]
@@ -3642,7 +3654,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-governance-proposals-amount-total-limit"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=f174aa82788f2dfc39b1cdb81fd19d691e77ac0b#f174aa82788f2dfc39b1cdb81fd19d691e77ac0b"
+source = "git+https://github.com/dfinity/ic?rev=cc4ea40e8571b80043013e4e74bd2b89844230c7#cc4ea40e8571b80043013e4e74bd2b89844230c7"
 dependencies = [
  "ic-sns-governance-token-valuation",
  "num-traits",
@@ -3653,7 +3665,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-governance-token-valuation"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=f174aa82788f2dfc39b1cdb81fd19d691e77ac0b#f174aa82788f2dfc39b1cdb81fd19d691e77ac0b"
+source = "git+https://github.com/dfinity/ic?rev=cc4ea40e8571b80043013e4e74bd2b89844230c7#cc4ea40e8571b80043013e4e74bd2b89844230c7"
 dependencies = [
  "async-trait",
  "candid",
@@ -3674,7 +3686,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-init"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f174aa82788f2dfc39b1cdb81fd19d691e77ac0b#f174aa82788f2dfc39b1cdb81fd19d691e77ac0b"
+source = "git+https://github.com/dfinity/ic?rev=cc4ea40e8571b80043013e4e74bd2b89844230c7#cc4ea40e8571b80043013e4e74bd2b89844230c7"
 dependencies = [
  "base64 0.13.1",
  "candid",
@@ -3701,7 +3713,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-root"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f174aa82788f2dfc39b1cdb81fd19d691e77ac0b#f174aa82788f2dfc39b1cdb81fd19d691e77ac0b"
+source = "git+https://github.com/dfinity/ic?rev=cc4ea40e8571b80043013e4e74bd2b89844230c7#cc4ea40e8571b80043013e4e74bd2b89844230c7"
 dependencies = [
  "async-trait",
  "build-info",
@@ -3730,7 +3742,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-swap"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f174aa82788f2dfc39b1cdb81fd19d691e77ac0b#f174aa82788f2dfc39b1cdb81fd19d691e77ac0b"
+source = "git+https://github.com/dfinity/ic?rev=cc4ea40e8571b80043013e4e74bd2b89844230c7#cc4ea40e8571b80043013e4e74bd2b89844230c7"
 dependencies = [
  "async-trait",
  "build-info",
@@ -3755,7 +3767,7 @@ dependencies = [
  "ic-utils 0.9.0",
  "icp-ledger",
  "icrc-ledger-types",
- "itertools",
+ "itertools 0.12.1",
  "lazy_static",
  "maplit",
  "prost",
@@ -3768,7 +3780,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-swap-proto-library"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=f174aa82788f2dfc39b1cdb81fd19d691e77ac0b#f174aa82788f2dfc39b1cdb81fd19d691e77ac0b"
+source = "git+https://github.com/dfinity/ic?rev=cc4ea40e8571b80043013e4e74bd2b89844230c7#cc4ea40e8571b80043013e4e74bd2b89844230c7"
 dependencies = [
  "candid",
  "comparable",
@@ -3783,7 +3795,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-wasm"
 version = "1.0.0"
-source = "git+https://github.com/dfinity/ic?rev=f174aa82788f2dfc39b1cdb81fd19d691e77ac0b#f174aa82788f2dfc39b1cdb81fd19d691e77ac0b"
+source = "git+https://github.com/dfinity/ic?rev=cc4ea40e8571b80043013e4e74bd2b89844230c7#cc4ea40e8571b80043013e4e74bd2b89844230c7"
 dependencies = [
  "async-trait",
  "candid",
@@ -3820,17 +3832,17 @@ dependencies = [
 
 [[package]]
 name = "ic-stable-structures"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07e2282054c8ddf0cb2a7abf5c174c373917b4345c9a096ae4aa7f7185cdcdc7"
+checksum = "03f3044466a69802de74e710dc0300b706a05696a0531c942ca856751a13b0db"
 dependencies = [
  "ic_principal",
 ]
 
 [[package]]
 name = "ic-transport-types"
-version = "0.35.0"
-source = "git+https://github.com/dfinity/agent-rs?rev=8273d321e9a09fd8373bd4e38b0676ec6ad9c260#8273d321e9a09fd8373bd4e38b0676ec6ad9c260"
+version = "0.36.0"
+source = "git+https://github.com/dfinity/agent-rs?rev=be929fd7967249c879f48f2f494cbfc5805a7d98#be929fd7967249c879f48f2f494cbfc5805a7d98"
 dependencies = [
  "candid",
  "hex",
@@ -3846,7 +3858,7 @@ dependencies = [
 [[package]]
 name = "ic-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f174aa82788f2dfc39b1cdb81fd19d691e77ac0b#f174aa82788f2dfc39b1cdb81fd19d691e77ac0b"
+source = "git+https://github.com/dfinity/ic?rev=cc4ea40e8571b80043013e4e74bd2b89844230c7#cc4ea40e8571b80043013e4e74bd2b89844230c7"
 dependencies = [
  "base64 0.13.1",
  "bincode",
@@ -3872,8 +3884,8 @@ dependencies = [
  "serde_cbor",
  "serde_json",
  "serde_with",
- "strum 0.26.2",
- "strum_macros 0.26.2",
+ "strum 0.26.3",
+ "strum_macros 0.26.4",
  "thiserror",
  "thousands",
 ]
@@ -3881,7 +3893,7 @@ dependencies = [
 [[package]]
 name = "ic-utils"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f174aa82788f2dfc39b1cdb81fd19d691e77ac0b#f174aa82788f2dfc39b1cdb81fd19d691e77ac0b"
+source = "git+https://github.com/dfinity/ic?rev=cc4ea40e8571b80043013e4e74bd2b89844230c7#cc4ea40e8571b80043013e4e74bd2b89844230c7"
 dependencies = [
  "hex",
  "scoped_threadpool",
@@ -3891,8 +3903,8 @@ dependencies = [
 
 [[package]]
 name = "ic-utils"
-version = "0.35.0"
-source = "git+https://github.com/dfinity/agent-rs?rev=8273d321e9a09fd8373bd4e38b0676ec6ad9c260#8273d321e9a09fd8373bd4e38b0676ec6ad9c260"
+version = "0.36.0"
+source = "git+https://github.com/dfinity/agent-rs?rev=be929fd7967249c879f48f2f494cbfc5805a7d98#be929fd7967249c879f48f2f494cbfc5805a7d98"
 dependencies = [
  "async-trait",
  "candid",
@@ -3918,7 +3930,7 @@ checksum = "583b1c03380cf86059160cc6c91dcbf56c7b5f141bf3a4f06bc79762d775fac4"
 dependencies = [
  "bls12_381",
  "lazy_static",
- "pairing",
+ "pairing 0.22.0",
  "sha2 0.9.9",
 ]
 
@@ -3930,7 +3942,7 @@ checksum = "a1f3f1ec63f08807d176691225de0b993e832b1fff71c631ed897df5888c7be4"
 dependencies = [
  "anyhow",
  "candid",
- "clap 4.5.4",
+ "clap 4.5.8",
  "libflate 2.1.0",
  "rustc-demangle",
  "serde",
@@ -3963,14 +3975,14 @@ checksum = "a54b5297861c651551676e8c43df805dad175cc33bc97dbd992edbbb85dcbcdf"
 
 [[package]]
 name = "ic_bls12_381"
-version = "0.8.0"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c682cb199cd8fcb582a6023325d571a6464edda26c8063fe04b6f6082a1a363c"
+checksum = "3fb94c398e5a5bc56a8f0ff995b2679829e2bbc5f145d9c3ea58d303036e05f2"
 dependencies = [
- "digest 0.9.0",
- "ff 0.12.1",
- "group 0.12.1",
- "pairing",
+ "digest 0.10.7",
+ "ff 0.13.0",
+ "group 0.13.0",
+ "pairing 0.23.0",
  "rand_core",
  "subtle",
  "zeroize",
@@ -3992,7 +4004,7 @@ dependencies = [
 [[package]]
 name = "icp-ledger"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f174aa82788f2dfc39b1cdb81fd19d691e77ac0b#f174aa82788f2dfc39b1cdb81fd19d691e77ac0b"
+source = "git+https://github.com/dfinity/ic?rev=cc4ea40e8571b80043013e4e74bd2b89844230c7#cc4ea40e8571b80043013e4e74bd2b89844230c7"
 dependencies = [
  "candid",
  "comparable",
@@ -4016,14 +4028,14 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_cbor",
- "strum 0.26.2",
- "strum_macros 0.26.2",
+ "strum 0.26.3",
+ "strum_macros 0.26.4",
 ]
 
 [[package]]
 name = "icrc-ledger-client"
 version = "0.1.2"
-source = "git+https://github.com/dfinity/ic?rev=f174aa82788f2dfc39b1cdb81fd19d691e77ac0b#f174aa82788f2dfc39b1cdb81fd19d691e77ac0b"
+source = "git+https://github.com/dfinity/ic?rev=cc4ea40e8571b80043013e4e74bd2b89844230c7#cc4ea40e8571b80043013e4e74bd2b89844230c7"
 dependencies = [
  "async-trait",
  "candid",
@@ -4034,19 +4046,20 @@ dependencies = [
 [[package]]
 name = "icrc-ledger-types"
 version = "0.1.5"
-source = "git+https://github.com/dfinity/ic?rev=f174aa82788f2dfc39b1cdb81fd19d691e77ac0b#f174aa82788f2dfc39b1cdb81fd19d691e77ac0b"
+source = "git+https://github.com/dfinity/ic?rev=cc4ea40e8571b80043013e4e74bd2b89844230c7#cc4ea40e8571b80043013e4e74bd2b89844230c7"
 dependencies = [
  "base32",
  "candid",
  "crc32fast",
  "hex",
- "itertools",
- "num-bigint 0.4.5",
+ "itertools 0.12.1",
+ "num-bigint 0.4.3",
  "num-traits",
  "serde",
  "serde_bytes",
  "sha2 0.10.8",
- "strum 0.26.2",
+ "strum 0.26.3",
+ "time",
 ]
 
 [[package]]
@@ -4155,6 +4168,15 @@ dependencies = [
 
 [[package]]
 name = "itertools"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
@@ -4249,11 +4271,11 @@ dependencies = [
 
 [[package]]
 name = "lazy_static"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 dependencies = [
- "spin 0.5.2",
+ "spin 0.9.8",
 ]
 
 [[package]]
@@ -4334,7 +4356,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "libc",
 ]
 
@@ -4372,9 +4394,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.21"
+version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
+checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
 name = "lzma-sys"
@@ -4395,9 +4417,9 @@ checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
 name = "memchr"
-version = "2.7.2"
+version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "memoffset"
@@ -4434,9 +4456,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87dfd01fe195c66b572b37921ad8803d010623c0aca821bea2302239d155cdae"
+checksum = "b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08"
 dependencies = [
  "adler",
 ]
@@ -4476,14 +4498,14 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.68",
 ]
 
 [[package]]
 name = "multimap"
-version = "0.10.0"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "defc4c55412d89136f966bbb339008b474350e5e6e78d2714439c386b3137a03"
+checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 
 [[package]]
 name = "native-tls"
@@ -4532,7 +4554,7 @@ dependencies = [
  "anyhow",
  "backoff",
  "candid",
- "clap 4.5.4",
+ "clap 4.5.8",
  "crc32fast",
  "dfx-core",
  "dfx-extensions-utils",
@@ -4544,7 +4566,7 @@ dependencies = [
  "ic-icrc1-index-ng",
  "ic-icrc1-ledger",
  "ic-sns-cli",
- "ic-utils 0.35.0",
+ "ic-utils 0.36.0",
  "reqwest 0.11.27",
  "rust_decimal",
  "serde",
@@ -4566,11 +4588,11 @@ dependencies = [
 
 [[package]]
 name = "num"
-version = "0.4.3"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+checksum = "b05180d69e3da0e530ba2a1dae5110317e49e3b7f3d41be227dc5f92e49ee7af"
 dependencies = [
- "num-bigint 0.4.5",
+ "num-bigint 0.4.3",
  "num-complex",
  "num-integer",
  "num-iter",
@@ -4591,10 +4613,11 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.5"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c165a9ab64cf766f73521c0dd2cfdff64f488b8f0b3e621face3462d3db536d7"
+checksum = "f93ab6289c7b344a8a9f60f88d80aa20032336fe78da341afc91c8a2341fc75f"
 dependencies = [
+ "autocfg",
  "num-integer",
  "num-traits",
  "serde",
@@ -4658,7 +4681,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
 dependencies = [
- "num-bigint 0.4.5",
+ "num-bigint 0.4.3",
  "num-integer",
  "num-traits",
 ]
@@ -4685,9 +4708,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.35.0"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8ec7ab813848ba4522158d5517a6093db1ded27575b070f4177b8d12b41db5e"
+checksum = "081b846d1d56ddfc18fdf1a922e4f6e07a11768ea1b92dec44e42b72712ccfce"
 dependencies = [
  "memchr",
 ]
@@ -4704,7 +4727,7 @@ dependencies = [
 [[package]]
 name = "on_wire"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f174aa82788f2dfc39b1cdb81fd19d691e77ac0b#f174aa82788f2dfc39b1cdb81fd19d691e77ac0b"
+source = "git+https://github.com/dfinity/ic?rev=cc4ea40e8571b80043013e4e74bd2b89844230c7#cc4ea40e8571b80043013e4e74bd2b89844230c7"
 
 [[package]]
 name = "once_cell"
@@ -4724,7 +4747,7 @@ version = "0.10.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95a0481286a310808298130d22dd1fef0fa571e05a8f44ec801801e84b216b1f"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -4741,7 +4764,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -4752,9 +4775,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-src"
-version = "300.3.0+3.3.0"
+version = "300.3.1+3.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eba8804a1c5765b18c4b3f907e6897ebabeedebc9830e1a0046c4a4cf44663e1"
+checksum = "7259953d42a81bf137fbbd73bd30a8e1914d6dce43c2b90ed575783a22608b91"
 dependencies = [
  "cc",
 ]
@@ -4800,6 +4823,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "pairing"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81fec4625e73cf41ef4bb6846cafa6d44736525f442ba45e407c4a000a13996f"
+dependencies = [
+ "group 0.13.0",
+]
+
+[[package]]
 name = "parking"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4823,9 +4855,9 @@ checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.1",
+ "redox_syscall 0.5.2",
  "smallvec",
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -4899,9 +4931,9 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pest"
-version = "2.7.10"
+version = "2.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "560131c633294438da9f7c4b08189194b20946c8274c6b9e38881a7874dc8ee8"
+checksum = "cd53dff83f26735fdc1ca837098ccf133605d794cdae66acfc2bfac3ec809d95"
 dependencies = [
  "memchr",
  "thiserror",
@@ -4910,9 +4942,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.7.10"
+version = "2.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26293c9193fbca7b1a3bf9b79dc1e388e927e6cacaa78b4a3ab705a1d3d41459"
+checksum = "2a548d2beca6773b1c244554d36fcf8548a8a58e74156968211567250e48e49a"
 dependencies = [
  "pest",
  "pest_generator",
@@ -4920,22 +4952,22 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.7.10"
+version = "2.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ec22af7d3fb470a85dd2ca96b7c577a1eb4ef6f1683a9fe9a8c16e136c04687"
+checksum = "3c93a82e8d145725dcbaf44e5ea887c8a869efdcc28706df2d08c69e17077183"
 dependencies = [
  "pest",
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.68",
 ]
 
 [[package]]
 name = "pest_meta"
-version = "2.7.10"
+version = "2.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a240022f37c361ec1878d646fc5b7d7c4d28d5946e1a80ad5a7a4f4ca0bdcd"
+checksum = "a941429fea7e08bedec25e4f6785b6ffaacc6b755da98df5ef3e7dcf4a124c4f"
 dependencies = [
  "once_cell",
  "pest",
@@ -4955,7 +4987,7 @@ dependencies = [
 [[package]]
 name = "phantom_newtype"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f174aa82788f2dfc39b1cdb81fd19d691e77ac0b#f174aa82788f2dfc39b1cdb81fd19d691e77ac0b"
+source = "git+https://github.com/dfinity/ic?rev=cc4ea40e8571b80043013e4e74bd2b89844230c7#cc4ea40e8571b80043013e4e74bd2b89844230c7"
 dependencies = [
  "candid",
  "serde",
@@ -4979,7 +5011,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -5029,12 +5061,6 @@ name = "pkg-config"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
-
-[[package]]
-name = "platforms"
-version = "3.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db23d408679286588f4d4644f965003d056e3dd5abcaaa938116871d7ce2fee7"
 
 [[package]]
 name = "polling"
@@ -5130,7 +5156,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f12335488a2f3b0a83b14edad48dca9879ce89b2edd10e80237e4e852dd645e"
 dependencies = [
  "proc-macro2",
- "syn 2.0.66",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -5212,18 +5238,18 @@ checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.84"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec96c6a92621310b51366f1e28d05ef11489516e93be030060e5fc12024a49d6"
+checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "prost"
-version = "0.12.6"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deb1435c188b76130da55f17a466d252ff7b1418b2ad3e037d127b94e3411f29"
+checksum = "5a5a410fc7882af66deb8d01d01737353cf3ad6204c408177ba494291a626312"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -5231,13 +5257,13 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.12.6"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22505a5c94da8e3b7c2996394d1c933236c4d743e81a410bcca4e6989fc066a4"
+checksum = "1fa3d084c8704911bfefb2771be2f9b6c5c0da7343a71e0021ee3c665cada738"
 dependencies = [
  "bytes",
- "heck 0.5.0",
- "itertools",
+ "heck 0.4.1",
+ "itertools 0.11.0",
  "log",
  "multimap",
  "once_cell",
@@ -5246,28 +5272,29 @@ dependencies = [
  "prost",
  "prost-types",
  "regex",
- "syn 2.0.66",
+ "syn 2.0.68",
  "tempfile",
+ "which",
 ]
 
 [[package]]
 name = "prost-derive"
-version = "0.12.6"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
+checksum = "065717a5dfaca4a83d2fe57db3487b311365200000551d7a364e715dbf4346bc"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.11.0",
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.68",
 ]
 
 [[package]]
 name = "prost-types"
-version = "0.12.6"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9091c90b0a32608e984ff2fa4091273cbdd755d54935c51d520887f4a1dbd5b0"
+checksum = "8339f32236f590281e2f6368276441394fcd1b2133b549cc895d0ae80f2f9a52"
 dependencies = [
  "prost",
 ]
@@ -5299,6 +5326,53 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "quinn"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4ceeeeabace7857413798eb1ffa1e9c905a9946a57d81fb69b4b71c4d8eb3ad"
+dependencies = [
+ "bytes",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls 0.23.10",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddf517c03a109db8100448a4be38d498df8a210a99fe0e1b9eaf39e78c640efe"
+dependencies = [
+ "bytes",
+ "rand",
+ "ring 0.17.8",
+ "rustc-hash",
+ "rustls 0.23.10",
+ "slab",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9096629c45860fc7fb143e125eb826b5e721e10be3263160c7d60ca832cf8c46"
+dependencies = [
+ "libc",
+ "once_cell",
+ "socket2 0.5.7",
+ "tracing",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5363,11 +5437,11 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "469052894dcb553421e483e4209ee581a45100d31b4018de03e5a7ad86374a7e"
+checksum = "c82cf8cff14456045f55ec4241383baeff27af886adb72ffb2162f99911de0fd"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
 ]
 
 [[package]]
@@ -5383,9 +5457,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.4"
+version = "1.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c117dbdfde9c8308975b6a18d71f3f385c89461f7b3fb054288ecf2a2058ba4c"
+checksum = "b91213439dad192326a0d7c6ee3955910425f441d7038e0d6933b0aec5c4517f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -5395,9 +5469,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
+checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -5406,19 +5480,18 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
+checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
 name = "registry-canister"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f174aa82788f2dfc39b1cdb81fd19d691e77ac0b#f174aa82788f2dfc39b1cdb81fd19d691e77ac0b"
+source = "git+https://github.com/dfinity/ic?rev=cc4ea40e8571b80043013e4e74bd2b89844230c7#cc4ea40e8571b80043013e4e74bd2b89844230c7"
 dependencies = [
  "build-info",
  "build-info-build",
  "candid",
- "cycles-minting-canister",
  "dfn_candid",
  "dfn_core",
  "dfn_http_metrics",
@@ -5475,7 +5548,7 @@ dependencies = [
  "h2",
  "http 0.2.12",
  "http-body 0.4.6",
- "hyper 0.14.28",
+ "hyper 0.14.29",
  "hyper-rustls 0.24.2",
  "hyper-tls",
  "ipnet",
@@ -5491,7 +5564,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper",
+ "sync_wrapper 0.1.2",
  "system-configuration",
  "tokio",
  "tokio-native-tls",
@@ -5507,9 +5580,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.12.4"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "566cafdd92868e0939d3fb961bd0dc25fcfaaed179291093b3d43e6b3150ea10"
+checksum = "c7d6d2a27d57148378eb5e111173f4276ad26340ecc5c49a4a2152167a2d6a37"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -5519,8 +5592,8 @@ dependencies = [
  "http 1.1.0",
  "http-body 1.0.0",
  "http-body-util",
- "hyper 1.3.1",
- "hyper-rustls 0.26.0",
+ "hyper 1.4.0",
+ "hyper-rustls 0.27.2",
  "hyper-util",
  "ipnet",
  "js-sys",
@@ -5529,15 +5602,16 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls 0.22.4",
+ "quinn",
+ "rustls 0.23.10",
  "rustls-pemfile 2.1.2",
  "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper",
+ "sync_wrapper 1.0.1",
  "tokio",
- "tokio-rustls 0.25.0",
+ "tokio-rustls 0.26.0",
  "tokio-util",
  "tower-service",
  "url",
@@ -5545,7 +5619,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots 0.26.1",
+ "webpki-roots 0.26.3",
  "winreg 0.52.0",
 ]
 
@@ -5720,7 +5794,7 @@ version = "0.38.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "errno",
  "libc",
  "linux-raw-sys 0.4.14",
@@ -5753,14 +5827,14 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.22.4"
+version = "0.23.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
+checksum = "05cff451f60db80f490f3c182b77c35260baace73209e9cdbbe526bfe3a4d402"
 dependencies = [
- "log",
+ "once_cell",
  "ring 0.17.8",
  "rustls-pki-types",
- "rustls-webpki 0.102.4",
+ "rustls-webpki 0.102.5",
  "subtle",
  "zeroize",
 ]
@@ -5814,9 +5888,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.102.4"
+version = "0.102.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff448f7e92e913c4b7d4c6d8e4540a1724b319b4152b8aef6d4cf8339712b33e"
+checksum = "f9a6fccd794a42c2c105b513a2f62bc3fd8f3ba57a4593677ceb0bd035164d78"
 dependencies = [
  "ring 0.17.8",
  "rustls-pki-types",
@@ -5865,7 +5939,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.66",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -5956,7 +6030,7 @@ version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c627723fd09706bacdb5cf41499e95098555af3c3c29d014dc3c458ef6be11c0"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -5993,9 +6067,9 @@ dependencies = [
 
 [[package]]
 name = "serde_bytes"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b8497c313fd43ab992087548117643f6fcd935cbf36f176ffda0aacf9591734"
+checksum = "387cc504cb06bb40a96c8e04e951fe01854cf6bc921053c954e4a606d9675c6a"
 dependencies = [
  "serde",
 ]
@@ -6018,7 +6092,7 @@ checksum = "500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -6029,14 +6103,14 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.68",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.117"
+version = "1.0.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "455182ea6142b14f93f4bc5320a2b31c1f266b66a4a5c858b013302a5d8cbfc3"
+checksum = "3d1c7e3eac408d115102c4c24ad393e0821bb3a5df4d506a80f85f7a742a526b"
 dependencies = [
  "itoa",
  "ryu",
@@ -6051,7 +6125,7 @@ checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -6184,7 +6258,7 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adc4e5204eb1910f40f9cfa375f6f05b68c3abac4b6fd879c8ff5e7ae8a0a085"
 dependencies = [
- "num-bigint 0.4.5",
+ "num-bigint 0.4.3",
  "num-traits",
  "thiserror",
  "time",
@@ -6254,12 +6328,13 @@ version = "0.4.2"
 dependencies = [
  "anyhow",
  "candid",
- "clap 4.5.4",
+ "clap 4.5.8",
  "dfx-core",
  "dfx-extensions-utils",
  "fn-error-context",
  "futures-util",
  "ic-sns-cli",
+ "serde_json",
  "slog",
  "tokio",
 ]
@@ -6361,11 +6436,11 @@ checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
 
 [[package]]
 name = "strum"
-version = "0.26.2"
+version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d8cec3501a5194c432b2b7976db6b7d10ec95c253208b45f83f7136aa985e29"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
 dependencies = [
- "strum_macros 0.26.2",
+ "strum_macros 0.26.4",
 ]
 
 [[package]]
@@ -6383,22 +6458,22 @@ dependencies = [
 
 [[package]]
 name = "strum_macros"
-version = "0.26.2"
+version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6cf59daf282c0a494ba14fd21610a0325f9f90ec9d1231dea26bcb1d696c946"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.66",
+ "syn 2.0.68",
 ]
 
 [[package]]
 name = "subtle"
-version = "2.5.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "subtle-ng"
@@ -6419,9 +6494,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.66"
+version = "2.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c42f3f41a2de00b01c0aaad383c5a45241efc8b2d1eda5661812fda5f3cdcff5"
+checksum = "901fa70d88b9d6c98022e23b4136f9f3e54e4662c3bc1bd1d84a42a9a0f0c1e9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6437,7 +6512,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -6447,6 +6522,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
+name = "sync_wrapper"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
+
+[[package]]
 name = "synstructure"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6454,7 +6535,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -6492,9 +6573,9 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tar"
-version = "0.4.40"
+version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b16afcea1f22891c49a00c751c7b63b2233284064f11a200fc624137c51e2ddb"
+checksum = "cb797dad5fb5b76fcf519e702f4a589483b5ef06567f160c392832c1f5e44909"
 dependencies = [
  "filetime",
  "libc",
@@ -6562,7 +6643,7 @@ checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -6633,9 +6714,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
+checksum = "ce6b6a2fb3a985e99cebfaefa9faa3024743da73304ca1c683a36429613d3d22"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -6648,9 +6729,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.37.0"
+version = "1.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1adbebffeca75fcfd058afa480fb6c0b81e165a0323f9c9d39c9697e37c46787"
+checksum = "ba4f4a02a7a80d6f274636f0aa95c7e383b912d41fe721a31f29e29698585a4a"
 dependencies = [
  "backtrace",
  "bytes",
@@ -6695,11 +6776,11 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.25.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
+checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
 dependencies = [
- "rustls 0.22.4",
+ "rustls 0.23.10",
  "rustls-pki-types",
  "tokio",
 ]
@@ -6788,7 +6869,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -6862,9 +6955,9 @@ checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68f5e5f3158ecfd4b8ff6fe086db7c8467a2dfdac97fe420f2b7c4aa97af66d6"
+checksum = "0336d538f7abc86d282a4189614dfaa90810dfc2c6f6427eaf88e16311dd225d"
 
 [[package]]
 name = "universal-hash"
@@ -6896,9 +6989,9 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
-version = "2.5.0"
+version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633"
+checksum = "22784dbdf76fdde8af1aeda5622b546b422b6fc585325248a2bf9f5e41e94d6c"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -6913,15 +7006,15 @@ checksum = "86bd8d4e895da8537e5315b8254664e6b769c4ff3db18321b297a1e7004392e3"
 
 [[package]]
 name = "utf8parse"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.8.0"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a183cf7feeba97b4dd1c0d46788634f6221d87fa961b305bed08c851829efcc0"
+checksum = "5de17fd2f7da591098415cff336e12965a28061ddace43b59cb3c430179c9439"
 
 [[package]]
 name = "vcpkg"
@@ -7005,7 +7098,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.68",
  "wasm-bindgen-shared",
 ]
 
@@ -7039,7 +7132,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.68",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -7115,11 +7208,23 @@ checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "webpki-roots"
-version = "0.26.1"
+version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3de34ae270483955a94f4b21bdaaeb83d508bb84a01435f393818edb0012009"
+checksum = "bd7c23921eeb1713a4e851530e9b9756e4fb0e89978582942612524cf09f01cd"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "which"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+dependencies = [
+ "either",
+ "home",
+ "once_cell",
+ "rustix 0.38.34",
 ]
 
 [[package]]
@@ -7159,7 +7264,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -7177,7 +7282,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -7197,18 +7302,18 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f0713a46559409d202e70e28227288446bf7841d3211583a4b53e3f6d96e7eb"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.5",
- "windows_aarch64_msvc 0.52.5",
- "windows_i686_gnu 0.52.5",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
  "windows_i686_gnullvm",
- "windows_i686_msvc 0.52.5",
- "windows_x86_64_gnu 0.52.5",
- "windows_x86_64_gnullvm 0.52.5",
- "windows_x86_64_msvc 0.52.5",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
 
 [[package]]
@@ -7219,9 +7324,9 @@ checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7088eed71e8b8dda258ecc8bac5fb1153c5cffaf2578fc8ff5d61e23578d3263"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -7231,9 +7336,9 @@ checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9985fd1504e250c615ca5f281c3f7a6da76213ebd5ccc9561496568a2752afb6"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -7243,15 +7348,15 @@ checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88ba073cf16d5372720ec942a8ccbf61626074c6d4dd2e745299726ce8b89670"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
 name = "windows_i686_gnullvm"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87f4261229030a858f36b459e748ae97545d6f1ec60e5e0d6a3d32e0dc232ee9"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -7261,9 +7366,9 @@ checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db3c2bf3d13d5b658be73463284eaf12830ac9a26a90c717b7f771dfe97487bf"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -7273,9 +7378,9 @@ checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e4246f76bdeff09eb48875a0fd3e2af6aada79d409d33011886d3e1581517d9"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -7285,9 +7390,9 @@ checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "852298e482cd67c356ddd9570386e2862b5673c85bd5f88df9ab6802b334c596"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -7297,9 +7402,9 @@ checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.5"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
@@ -7419,22 +7524,22 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.7.34"
+version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae87e3fcd617500e5d106f0380cf7b77f3c6092aae37191433159dda23cfb087"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.7.34"
+version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15e934569e47891f7d9411f1a451d947a60e000ab3bd24fbb970f000387d1b3b"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -7454,7 +7559,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.66",
+ "syn 2.0.68",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "Apache-2.0"
 repository = "https://github.com/dfinity/dfx-extensions"
 
 [workspace.dependencies]
-dfx-core = { git = "https://github.com/dfinity/sdk", rev = "cb67f24b7acb9aaa4609f38a34527a9436fb6b72" }
+dfx-core = { git = "https://github.com/dfinity/sdk", rev = "d8c1ede88d1978653d2e7d7005095fe38499e023" }
 dfx-extensions-utils.path = "./extensions-utils"
 
 anyhow = "^1"
@@ -21,8 +21,8 @@ flate2 = { version = "1.0.25", default-features = false, features = [
 ] }
 fn-error-context = "0.2.1"
 futures-util = "0.3.28"
-ic-agent = { git = "https://github.com/dfinity/agent-rs", rev = "8273d321e9a09fd8373bd4e38b0676ec6ad9c260" }
-ic-utils = { git = "https://github.com/dfinity/agent-rs", rev = "8273d321e9a09fd8373bd4e38b0676ec6ad9c260" }
+ic-agent = { git = "https://github.com/dfinity/agent-rs", rev = "be929fd7967249c879f48f2f494cbfc5805a7d98" }
+ic-utils = { git = "https://github.com/dfinity/agent-rs", rev = "be929fd7967249c879f48f2f494cbfc5805a7d98" }
 reqwest = { version = "^0.11.22", default-features = false, features = [
     "blocking",
     "json",
@@ -34,10 +34,11 @@ slog = "^2.7.0"
 tempfile = "3.5.0"
 tokio = { version = "^1.36.0", features = ["rt-multi-thread"] }
 url = "^2.4.1"
-ic-icp-index = { git = "https://github.com/dfinity/ic", rev = "f174aa82788f2dfc39b1cdb81fd19d691e77ac0b" }
-ic-icrc1-index-ng = { git = "https://github.com/dfinity/ic", rev = "f174aa82788f2dfc39b1cdb81fd19d691e77ac0b" }
-ic-icrc1-ledger = { git = "https://github.com/dfinity/ic", rev = "f174aa82788f2dfc39b1cdb81fd19d691e77ac0b" }
-ic-sns-cli = { git = "https://github.com/dfinity/ic", rev = "f174aa82788f2dfc39b1cdb81fd19d691e77ac0b" }
+ic-icp-index = { git = "https://github.com/dfinity/ic", rev = "cc4ea40e8571b80043013e4e74bd2b89844230c7" }
+ic-icrc1-index-ng = { git = "https://github.com/dfinity/ic", rev = "cc4ea40e8571b80043013e4e74bd2b89844230c7" }
+ic-icrc1-ledger = { git = "https://github.com/dfinity/ic", rev = "cc4ea40e8571b80043013e4e74bd2b89844230c7" }
+ic-sns-cli = { git = "https://github.com/dfinity/ic", rev = "cc4ea40e8571b80043013e4e74bd2b89844230c7" }
+serde_json = "1.0.79"
 
 # Config for 'cargo dist'
 [workspace.metadata.dist]

--- a/extensions-utils/Cargo.toml
+++ b/extensions-utils/Cargo.toml
@@ -17,16 +17,18 @@ reqwest.workspace = true
 dfx-core.workspace = true
 
 anyhow.workspace = true
-backoff = { version = "0.4.0", features = [ "futures", "tokio" ] }
-flate2 = { version = "1.0.25", default-features = false, features = ["zlib-ng"] }
+backoff = { version = "0.4.0", features = ["futures", "tokio"] }
+flate2 = { version = "1.0.25", default-features = false, features = [
+    "zlib-ng",
+] }
 fn-error-context.workspace = true
 futures-util.workspace = true
 hyper-rustls = { version = "0.23.0", features = ["webpki-roots", "http2"] }
 reqwest.workspace = true
 rustls = "0.20.4"
 semver = "1.0.17"
-serde = "1.0.159"
-serde_json = "1.0.95"
+serde.workspace = true
+serde_json.workspace = true
 slog-async = "2.4.0"
 slog-term = "2.9.0"
 slog.workspace = true
@@ -35,3 +37,4 @@ thiserror = "1.0.40"
 tokio.workspace = true
 url.workspace = true
 candid.workspace = true
+clap.workspace = true

--- a/extensions-utils/src/lib.rs
+++ b/extensions-utils/src/lib.rs
@@ -3,6 +3,7 @@
 pub mod dependencies;
 mod error;
 mod logger;
+pub mod manifest;
 mod project;
 
 pub use dependencies::{

--- a/extensions-utils/src/manifest.rs
+++ b/extensions-utils/src/manifest.rs
@@ -1,0 +1,98 @@
+use anyhow::{bail, Context};
+use dfx_core::extension::manifest::*;
+use extension::*;
+use std::{collections::BTreeMap, path::Path};
+
+fn generate_extension_manifest(
+    cmd: &clap::Command,
+    old_manifest: ExtensionManifest,
+) -> ExtensionManifest {
+    ExtensionManifest {
+        name: cmd.get_name().to_string(),
+        summary: cmd.get_about().map(|a| a.to_string()).unwrap_or_default(),
+        description: cmd.get_long_about().map(|a| a.to_string()),
+        subcommands: Some(generate_subcommands(cmd)),
+        ..old_manifest
+    }
+}
+
+fn generate_subcommands(cmd: &clap::Command) -> ExtensionSubcommandsOpts {
+    let mut subcommands = BTreeMap::new();
+
+    for subcmd in cmd.get_subcommands() {
+        subcommands.insert(
+            subcmd.get_name().to_string(),
+            ExtensionSubcommandOpts {
+                about: subcmd.get_about().map(|a| a.to_string()),
+                args: Some(generate_args(subcmd)),
+                subcommands: if subcmd.has_subcommands() {
+                    Some(generate_subcommands(subcmd))
+                } else {
+                    None
+                },
+            },
+        );
+    }
+
+    ExtensionSubcommandsOpts(subcommands)
+}
+
+fn generate_args(cmd: &clap::Command) -> BTreeMap<String, ExtensionSubcommandArgOpts> {
+    let mut args = BTreeMap::new();
+
+    for arg in cmd.get_arguments() {
+        args.insert(
+            arg.get_id().to_string(),
+            #[allow(deprecated)]
+            ExtensionSubcommandArgOpts {
+                about: arg.get_help().map(|h| h.to_string()),
+                long: arg.get_long().map(|l| l.to_string()),
+                short: arg.get_short(),
+                multiple: false, // Deprecated, set to false
+                values: match arg.get_num_args() {
+                    None => ArgNumberOfValues::Number(if arg.get_action().takes_values() {
+                        1
+                    } else {
+                        0
+                    }),
+                    Some(value_range) => {
+                        let min = value_range.min_values();
+                        let max = value_range.max_values();
+                        if min == 0 && max == usize::MAX {
+                            ArgNumberOfValues::Unlimited
+                        } else if min == max {
+                            ArgNumberOfValues::Number(min as usize)
+                        } else {
+                            // max is inclusive, but ArgNumberOfValues::Range wants an exclusive range
+                            ArgNumberOfValues::Range(min..(max.saturating_add(1)))
+                        }
+                    }
+                },
+            },
+        );
+    }
+
+    args
+}
+
+pub fn verify_extension_manifest<Command: clap::CommandFactory>(path: &Path) -> anyhow::Result<()> {
+    // read the mainfest from the path and deserizlize it
+    let current_manifest_string = std::fs::read_to_string(path).context(format!(
+        "Could not read the extension manifest at {}",
+        path.display(),
+    ))?;
+    let current_manifest: ExtensionManifest = serde_json::from_str(&current_manifest_string)?;
+
+    let command_info = Command::command();
+    let updated_manifest = generate_extension_manifest(&command_info, current_manifest);
+
+    let updated_manifest_string = serde_json::to_string_pretty(&updated_manifest)?;
+    // write the json to the path
+    if updated_manifest_string != current_manifest_string {
+        std::fs::write(path, updated_manifest_string)?;
+        bail!(
+            "Extension manifest at {} was out of date. This has been fixed. Please commit the changes.", path.display()
+        );
+    }
+    Ok(())
+}

--- a/extensions/nns/build.rs
+++ b/extensions/nns/build.rs
@@ -1,7 +1,7 @@
 use std::env;
 use std::path::PathBuf;
 
-const REPLICA_REV: &str = "f174aa82788f2dfc39b1cdb81fd19d691e77ac0b";
+const REPLICA_REV: &str = "cc4ea40e8571b80043013e4e74bd2b89844230c7";
 
 const BINARY_DEPENDENCIES: &[(&str, &str)] = &[
     // (downloaded binary name, renamed binary name)

--- a/extensions/sns/Cargo.toml
+++ b/extensions/sns/Cargo.toml
@@ -12,6 +12,7 @@ build = "build.rs"
 dfx-extensions-utils.workspace = true
 
 [dependencies]
+serde_json.workspace = true
 dfx-core.workspace = true
 dfx-extensions-utils.workspace = true
 ic-sns-cli.workspace = true

--- a/extensions/sns/build.rs
+++ b/extensions/sns/build.rs
@@ -1,7 +1,7 @@
 use std::env;
 use std::path::PathBuf;
 
-const REPLICA_REV: &str = "f174aa82788f2dfc39b1cdb81fd19d691e77ac0b";
+const REPLICA_REV: &str = "cc4ea40e8571b80043013e4e74bd2b89844230c7";
 
 const BINARY_DEPENDENCIES: &[(&str, &str)] = &[
     // (downloaded binary name, renamed binary name)

--- a/extensions/sns/e2e/assets/sns/valid/sns_init.yaml
+++ b/extensions/sns/e2e/assets/sns/valid/sns_init.yaml
@@ -97,7 +97,7 @@ Swap:
         - CH
 
     VestingSchedule:
-        events: 83
+        events: 5
         interval: 17 days
 
     start_time: 12:00 UTC

--- a/extensions/sns/src/main.rs
+++ b/extensions/sns/src/main.rs
@@ -112,3 +112,14 @@ fn main() -> anyhow::Result<()> {
     }?;
     Ok(())
 }
+
+#[test]
+fn verify_extension_manifest() {
+    let project_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    println!("Project root: {:?}", project_root);
+
+    let dest_path = project_root.join("extension.json");
+
+    dfx_extensions_utils::manifest::verify_extension_manifest::<SubCommand>(dest_path.as_path())
+        .unwrap();
+}


### PR DESCRIPTION
With this PR, the `sns` DFX extension's `extension.json` can now be automatically updated by running `cargo test`. If the extension.json has been updated, the test fails, so CI will fail if you try to commit a change that requires a change to extension.json. This means that the developer can just run `cargo test` before committing, which will fail the first time and then succeed the second time. This may be slightly unintuitive but I think it is a good developer experience, as they'll likely run `cargo test` at least once during development anyway.

I plan to add this for the `nns` extension as well at some point.
