### PR TITLE
feat(sns): Add `list` and `add-sns-wasm-for-tests` command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -298,6 +298,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1178,7 +1184,7 @@ dependencies = [
 [[package]]
 name = "cycles-minting-canister"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5849c6daf2037349bd36dcb6e26ce61c2c6570d0#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
 dependencies = [
  "async-trait",
  "base64 0.13.1",
@@ -1212,7 +1218,7 @@ dependencies = [
  "rand",
  "serde",
  "serde_cbor",
- "sha2 0.9.9",
+ "sha2 0.10.8",
  "yansi",
 ]
 
@@ -1222,8 +1228,18 @@ version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a01d95850c592940db9b8194bc39f4bc0e89dee5c4265e4b1807c34a9aba453c"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.13.4",
+ "darling_macro 0.13.4",
+]
+
+[[package]]
+name = "darling"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
+dependencies = [
+ "darling_core 0.20.10",
+ "darling_macro 0.20.10",
 ]
 
 [[package]]
@@ -1241,14 +1257,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim 0.11.1",
+ "syn 2.0.77",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
 dependencies = [
- "darling_core",
+ "darling_core 0.13.4",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
+dependencies = [
+ "darling_core 0.20.10",
+ "quote",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -1336,7 +1377,7 @@ dependencies = [
 [[package]]
 name = "dfn_candid"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5849c6daf2037349bd36dcb6e26ce61c2c6570d0#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
 dependencies = [
  "candid",
  "dfn_core",
@@ -1348,7 +1389,7 @@ dependencies = [
 [[package]]
 name = "dfn_core"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5849c6daf2037349bd36dcb6e26ce61c2c6570d0#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
 dependencies = [
  "ic-base-types",
  "on_wire",
@@ -1357,7 +1398,7 @@ dependencies = [
 [[package]]
 name = "dfn_http"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5849c6daf2037349bd36dcb6e26ce61c2c6570d0#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
 dependencies = [
  "candid",
  "dfn_candid",
@@ -1369,11 +1410,12 @@ dependencies = [
 [[package]]
 name = "dfn_http_metrics"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5849c6daf2037349bd36dcb6e26ce61c2c6570d0#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
 dependencies = [
  "dfn_candid",
  "dfn_core",
  "dfn_http",
+ "ic-canisters-http-types",
  "ic-metrics-encoder",
  "serde_bytes",
 ]
@@ -1381,7 +1423,7 @@ dependencies = [
 [[package]]
 name = "dfn_protobuf"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5849c6daf2037349bd36dcb6e26ce61c2c6570d0#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
 dependencies = [
  "on_wire",
  "prost",
@@ -1407,7 +1449,7 @@ dependencies = [
  "handlebars",
  "hex",
  "humantime-serde",
- "ic-agent",
+ "ic-agent 0.37.1 (git+https://github.com/dfinity/agent-rs?rev=6e11a350112f9b907c4d590d8217f340e153d898)",
  "ic-identity-hsm",
  "ic-utils 0.37.1",
  "itertools 0.10.5",
@@ -1785,7 +1827,7 @@ checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
 [[package]]
 name = "fe-derive"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5849c6daf2037349bd36dcb6e26ce61c2c6570d0#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
 dependencies = [
  "hex",
  "num-bigint-dig",
@@ -2104,6 +2146,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524e8ac6999421f49a846c2d4411f337e53497d8ec55d67753beffa43c5d9205"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http 1.1.0",
+ "indexmap 2.5.0",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "half"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2150,6 +2211,7 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
  "ahash 0.8.11",
  "allocator-api2",
+ "serde",
 ]
 
 [[package]]
@@ -2291,6 +2353,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-body-to-bytes"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17a08236c6f51c2ee95d840f45acf8fa9e339390e00b4ef640857b2f2a534d70"
+dependencies = [
+ "bytes",
+ "http-body 1.0.1",
+ "http-body-util",
+]
+
+[[package]]
 name = "http-body-util"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2341,7 +2414,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
+ "h2 0.3.26",
  "http 0.2.12",
  "http-body 0.4.6",
  "httparse",
@@ -2364,6 +2437,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
+ "h2 0.4.6",
  "http 1.1.0",
  "http-body 1.0.1",
  "httparse",
@@ -2481,6 +2555,53 @@ dependencies = [
 [[package]]
 name = "ic-agent"
 version = "0.37.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fd3fdf5e5c4f4a9fe5ca612f0febd22dcb161d2f2b75b0142326732be5e4978"
+dependencies = [
+ "async-lock 3.4.0",
+ "backoff",
+ "cached 0.52.0",
+ "candid",
+ "ed25519-consensus",
+ "futures-util",
+ "hex",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "http-body-to-bytes",
+ "http-body-util",
+ "hyper 1.4.1",
+ "hyper-rustls 0.27.3",
+ "hyper-util",
+ "ic-certification",
+ "ic-transport-types 0.37.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-verify-bls-signature",
+ "k256 0.13.3",
+ "leb128",
+ "p256",
+ "pem 3.0.4",
+ "pkcs8 0.10.2",
+ "rand",
+ "rangemap",
+ "reqwest 0.12.7",
+ "ring 0.17.8",
+ "rustls-webpki 0.102.7",
+ "sec1 0.7.3",
+ "serde",
+ "serde_bytes",
+ "serde_cbor",
+ "serde_repr",
+ "sha2 0.10.8",
+ "simple_asn1",
+ "thiserror",
+ "time",
+ "tokio",
+ "tower",
+ "url",
+]
+
+[[package]]
+name = "ic-agent"
+version = "0.37.1"
 source = "git+https://github.com/dfinity/agent-rs?rev=6e11a350112f9b907c4d590d8217f340e153d898#6e11a350112f9b907c4d590d8217f340e153d898"
 dependencies = [
  "async-lock 3.4.0",
@@ -2493,7 +2614,7 @@ dependencies = [
  "http 1.1.0",
  "http-body 1.0.1",
  "ic-certification",
- "ic-transport-types",
+ "ic-transport-types 0.37.1 (git+https://github.com/dfinity/agent-rs?rev=6e11a350112f9b907c4d590d8217f340e153d898)",
  "ic-verify-bls-signature",
  "k256 0.13.3",
  "leb128",
@@ -2521,7 +2642,7 @@ dependencies = [
 [[package]]
 name = "ic-base-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5849c6daf2037349bd36dcb6e26ce61c2c6570d0#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
 dependencies = [
  "byte-unit",
  "bytes",
@@ -2546,9 +2667,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "ic-btc-types-internal"
+name = "ic-btc-replica-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5849c6daf2037349bd36dcb6e26ce61c2c6570d0#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
 dependencies = [
  "candid",
  "ic-btc-interface",
@@ -2561,11 +2682,11 @@ dependencies = [
 [[package]]
 name = "ic-canister-client-sender"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5849c6daf2037349bd36dcb6e26ce61c2c6570d0#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
 dependencies = [
  "ic-base-types",
- "ic-crypto-ecdsa-secp256k1",
  "ic-crypto-ed25519",
+ "ic-crypto-secp256k1",
  "ic-types",
  "rand",
  "rand_chacha",
@@ -2574,7 +2695,7 @@ dependencies = [
 [[package]]
 name = "ic-canister-log"
 version = "0.2.0"
-source = "git+https://github.com/dfinity/ic?rev=5849c6daf2037349bd36dcb6e26ce61c2c6570d0#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
 dependencies = [
  "serde",
 ]
@@ -2582,7 +2703,7 @@ dependencies = [
 [[package]]
 name = "ic-canister-profiler"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5849c6daf2037349bd36dcb6e26ce61c2c6570d0#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
 dependencies = [
  "ic-metrics-encoder",
  "ic0 0.18.11",
@@ -2591,9 +2712,10 @@ dependencies = [
 [[package]]
 name = "ic-canisters-http-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5849c6daf2037349bd36dcb6e26ce61c2c6570d0#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
 dependencies = [
  "candid",
+ "dfn_candid",
  "serde",
  "serde_bytes",
 ]
@@ -2679,40 +2801,26 @@ dependencies = [
 [[package]]
 name = "ic-constants"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5849c6daf2037349bd36dcb6e26ce61c2c6570d0#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
-
-[[package]]
-name = "ic-crypto-ecdsa-secp256k1"
-version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5849c6daf2037349bd36dcb6e26ce61c2c6570d0#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
-dependencies = [
- "k256 0.13.3",
- "lazy_static",
- "num-bigint 0.4.6",
- "pem 1.1.1",
- "rand",
- "simple_asn1",
- "zeroize",
-]
+source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
 
 [[package]]
 name = "ic-crypto-ed25519"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5849c6daf2037349bd36dcb6e26ce61c2c6570d0#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
 dependencies = [
  "curve25519-dalek",
  "ed25519-dalek",
  "hkdf 0.12.4",
  "pem 1.1.1",
  "rand",
- "sha2 0.10.8",
+ "thiserror",
  "zeroize",
 ]
 
 [[package]]
 name = "ic-crypto-getrandom-for-wasm"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5849c6daf2037349bd36dcb6e26ce61c2c6570d0#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
 dependencies = [
  "getrandom",
 ]
@@ -2720,7 +2828,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-basic-sig-der-utils"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5849c6daf2037349bd36dcb6e26ce61c2c6570d0#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
 dependencies = [
  "hex",
  "ic-types",
@@ -2730,11 +2838,10 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-basic-sig-ed25519"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5849c6daf2037349bd36dcb6e26ce61c2c6570d0#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
 dependencies = [
  "base64 0.13.1",
  "curve25519-dalek",
- "ed25519-consensus",
  "hex",
  "ic-crypto-ed25519",
  "ic-crypto-internal-basic-sig-der-utils",
@@ -2753,17 +2860,17 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-bls12-381-type"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5849c6daf2037349bd36dcb6e26ce61c2c6570d0#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
 dependencies = [
  "hex",
- "ic_bls12_381 0.8.0",
+ "ic_bls12_381",
  "itertools 0.12.1",
  "lazy_static",
- "pairing 0.22.0",
+ "pairing",
  "paste",
  "rand",
  "rand_chacha",
- "sha2 0.9.9",
+ "sha2 0.10.8",
  "subtle",
  "zeroize",
 ]
@@ -2771,7 +2878,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-hmac"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5849c6daf2037349bd36dcb6e26ce61c2c6570d0#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
 dependencies = [
  "ic-crypto-internal-sha2",
 ]
@@ -2779,7 +2886,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-multi-sig-bls12381"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5849c6daf2037349bd36dcb6e26ce61c2c6570d0#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
 dependencies = [
  "base64 0.13.1",
  "hex",
@@ -2798,7 +2905,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-seed"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5849c6daf2037349bd36dcb6e26ce61c2c6570d0#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
 dependencies = [
  "hex",
  "ic-crypto-sha2",
@@ -2811,7 +2918,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-sha2"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5849c6daf2037349bd36dcb6e26ce61c2c6570d0#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
 dependencies = [
  "sha2 0.10.8",
 ]
@@ -2819,7 +2926,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-threshold-sig-bls12381"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5849c6daf2037349bd36dcb6e26ce61c2c6570d0#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
 dependencies = [
  "base64 0.13.1",
  "cached 0.49.3",
@@ -2845,7 +2952,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-threshold-sig-ecdsa"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5849c6daf2037349bd36dcb6e26ce61c2c6570d0#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
 dependencies = [
  "curve25519-dalek",
  "fe-derive",
@@ -2875,7 +2982,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5849c6daf2037349bd36dcb6e26ce61c2c6570d0#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
 dependencies = [
  "arrayvec 0.7.6",
  "hex",
@@ -2892,7 +2999,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-node-key-validation"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5849c6daf2037349bd36dcb6e26ce61c2c6570d0#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
 dependencies = [
  "hex",
  "ic-base-types",
@@ -2908,9 +3015,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "ic-crypto-secp256k1"
+version = "0.9.0"
+source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
+dependencies = [
+ "hmac 0.12.1",
+ "k256 0.13.3",
+ "lazy_static",
+ "num-bigint 0.4.6",
+ "pem 1.1.1",
+ "rand",
+ "rand_chacha",
+ "simple_asn1",
+ "zeroize",
+]
+
+[[package]]
 name = "ic-crypto-secrets-containers"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5849c6daf2037349bd36dcb6e26ce61c2c6570d0#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
 dependencies = [
  "serde",
  "zeroize",
@@ -2919,7 +3042,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-sha2"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5849c6daf2037349bd36dcb6e26ce61c2c6570d0#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
 dependencies = [
  "ic-crypto-internal-sha2",
 ]
@@ -2927,7 +3050,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-tls-cert-validation"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5849c6daf2037349bd36dcb6e26ce61c2c6570d0#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
 dependencies = [
  "hex",
  "ic-crypto-internal-basic-sig-ed25519",
@@ -2940,7 +3063,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-tree-hash"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5849c6daf2037349bd36dcb6e26ce61c2c6570d0#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
 dependencies = [
  "ic-crypto-internal-types",
  "ic-crypto-sha2",
@@ -2953,7 +3076,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-utils-basic-sig"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5849c6daf2037349bd36dcb6e26ce61c2c6570d0#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
 dependencies = [
  "ic-base-types",
  "ic-crypto-ed25519",
@@ -2963,7 +3086,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-utils-ni-dkg"
 version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=5849c6daf2037349bd36dcb6e26ce61c2c6570d0#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
 dependencies = [
  "ic-crypto-internal-types",
  "ic-protobuf",
@@ -2973,7 +3096,7 @@ dependencies = [
 [[package]]
 name = "ic-error-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5849c6daf2037349bd36dcb6e26ce61c2c6570d0#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
 dependencies = [
  "ic-protobuf",
  "ic-utils 0.9.0",
@@ -2985,7 +3108,7 @@ dependencies = [
 [[package]]
 name = "ic-icp-index"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5849c6daf2037349bd36dcb6e26ce61c2c6570d0#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
 dependencies = [
  "candid",
  "ciborium",
@@ -3013,13 +3136,14 @@ dependencies = [
 [[package]]
 name = "ic-icrc1"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5849c6daf2037349bd36dcb6e26ce61c2c6570d0#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
 dependencies = [
  "candid",
  "ciborium",
  "hex",
  "ic-base-types",
  "ic-crypto-sha2",
+ "ic-icrc1-tokens-u64",
  "ic-ledger-canister-core",
  "ic-ledger-core",
  "ic-ledger-hash-of",
@@ -3035,7 +3159,7 @@ dependencies = [
 [[package]]
 name = "ic-icrc1-index-ng"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5849c6daf2037349bd36dcb6e26ce61c2c6570d0#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
 dependencies = [
  "candid",
  "ciborium",
@@ -3063,7 +3187,7 @@ dependencies = [
 [[package]]
 name = "ic-icrc1-ledger"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5849c6daf2037349bd36dcb6e26ce61c2c6570d0#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
 dependencies = [
  "async-trait",
  "candid",
@@ -3091,7 +3215,7 @@ dependencies = [
 [[package]]
 name = "ic-icrc1-tokens-u64"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=5849c6daf2037349bd36dcb6e26ce61c2c6570d0#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
 dependencies = [
  "candid",
  "ic-ledger-core",
@@ -3106,7 +3230,7 @@ version = "0.37.1"
 source = "git+https://github.com/dfinity/agent-rs?rev=6e11a350112f9b907c4d590d8217f340e153d898#6e11a350112f9b907c4d590d8217f340e153d898"
 dependencies = [
  "hex",
- "ic-agent",
+ "ic-agent 0.37.1 (git+https://github.com/dfinity/agent-rs?rev=6e11a350112f9b907c4d590d8217f340e153d898)",
  "pkcs11",
  "sha2 0.10.8",
  "simple_asn1",
@@ -3116,7 +3240,7 @@ dependencies = [
 [[package]]
 name = "ic-ledger-canister-core"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5849c6daf2037349bd36dcb6e26ce61c2c6570d0#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
 dependencies = [
  "async-trait",
  "candid",
@@ -3134,7 +3258,7 @@ dependencies = [
 [[package]]
 name = "ic-ledger-core"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5849c6daf2037349bd36dcb6e26ce61c2c6570d0#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
 dependencies = [
  "candid",
  "ic-ledger-hash-of",
@@ -3146,7 +3270,7 @@ dependencies = [
 [[package]]
 name = "ic-ledger-hash-of"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=5849c6daf2037349bd36dcb6e26ce61c2c6570d0#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
 dependencies = [
  "candid",
  "hex",
@@ -3156,14 +3280,15 @@ dependencies = [
 [[package]]
 name = "ic-management-canister-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5849c6daf2037349bd36dcb6e26ce61c2c6570d0#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
 dependencies = [
  "candid",
  "ic-base-types",
  "ic-btc-interface",
- "ic-btc-types-internal",
+ "ic-btc-replica-types",
  "ic-error-types",
  "ic-protobuf",
+ "ic-utils 0.9.0",
  "num-traits",
  "serde",
  "serde_bytes",
@@ -3179,9 +3304,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b5c7628eac357aecda461130f8074468be5aa4d258a002032d82d817f79f1f8"
 
 [[package]]
+name = "ic-nervous-system-agent"
+version = "0.0.1"
+source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
+dependencies = [
+ "anyhow",
+ "candid",
+ "ic-agent 0.37.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-base-types",
+ "ic-nervous-system-clients",
+ "ic-nns-constants",
+ "ic-sns-governance",
+ "ic-sns-wasm",
+ "serde",
+ "tempfile",
+ "tokio",
+]
+
+[[package]]
 name = "ic-nervous-system-clients"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=5849c6daf2037349bd36dcb6e26ce61c2c6570d0#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
 dependencies = [
  "async-trait",
  "candid",
@@ -3204,12 +3347,12 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-collections-union-multi-map"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=5849c6daf2037349bd36dcb6e26ce61c2c6570d0#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
 
 [[package]]
 name = "ic-nervous-system-common"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5849c6daf2037349bd36dcb6e26ce61c2c6570d0#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
 dependencies = [
  "async-trait",
  "base64 0.13.1",
@@ -3245,12 +3388,12 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-common-build-metadata"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5849c6daf2037349bd36dcb6e26ce61c2c6570d0#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
 
 [[package]]
 name = "ic-nervous-system-common-test-keys"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5849c6daf2037349bd36dcb6e26ce61c2c6570d0#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
 dependencies = [
  "ic-base-types",
  "ic-canister-client-sender",
@@ -3263,7 +3406,7 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-governance"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=5849c6daf2037349bd36dcb6e26ce61c2c6570d0#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
 dependencies = [
  "ic-base-types",
  "ic-stable-structures",
@@ -3275,7 +3418,7 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-humanize"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5849c6daf2037349bd36dcb6e26ce61c2c6570d0#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
 dependencies = [
  "humantime",
  "ic-nervous-system-proto",
@@ -3287,12 +3430,12 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-lock"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=5849c6daf2037349bd36dcb6e26ce61c2c6570d0#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
 
 [[package]]
 name = "ic-nervous-system-proto"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5849c6daf2037349bd36dcb6e26ce61c2c6570d0#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
 dependencies = [
  "candid",
  "comparable",
@@ -3305,7 +3448,7 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-proxied-canister-calls-tracker"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5849c6daf2037349bd36dcb6e26ce61c2c6570d0#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
 dependencies = [
  "ic-base-types",
 ]
@@ -3313,7 +3456,7 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-root"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5849c6daf2037349bd36dcb6e26ce61c2c6570d0#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
 dependencies = [
  "candid",
  "dfn_core",
@@ -3329,7 +3472,7 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-runtime"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5849c6daf2037349bd36dcb6e26ce61c2c6570d0#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
 dependencies = [
  "async-trait",
  "candid",
@@ -3342,12 +3485,17 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-string"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=5849c6daf2037349bd36dcb6e26ce61c2c6570d0#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
+
+[[package]]
+name = "ic-nervous-system-temporary"
+version = "0.0.1"
+source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
 
 [[package]]
 name = "ic-neurons-fund"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=5849c6daf2037349bd36dcb6e26ce61c2c6570d0#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
 dependencies = [
  "ic-nervous-system-common",
  "lazy_static",
@@ -3360,7 +3508,7 @@ dependencies = [
 [[package]]
 name = "ic-nns-common"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5849c6daf2037349bd36dcb6e26ce61c2c6570d0#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
 dependencies = [
  "candid",
  "comparable",
@@ -3380,13 +3528,13 @@ dependencies = [
  "prost",
  "serde",
  "serde_bytes",
- "sha2 0.9.9",
+ "sha2 0.10.8",
 ]
 
 [[package]]
 name = "ic-nns-constants"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5849c6daf2037349bd36dcb6e26ce61c2c6570d0#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
 dependencies = [
  "ic-base-types",
  "maplit",
@@ -3395,7 +3543,7 @@ dependencies = [
 [[package]]
 name = "ic-nns-governance"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5849c6daf2037349bd36dcb6e26ce61c2c6570d0#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
 dependencies = [
  "async-trait",
  "build-info",
@@ -3414,6 +3562,7 @@ dependencies = [
  "ic-crypto-getrandom-for-wasm",
  "ic-crypto-sha2",
  "ic-ledger-core",
+ "ic-management-canister-types",
  "ic-metrics-encoder",
  "ic-nervous-system-clients",
  "ic-nervous-system-common",
@@ -3423,10 +3572,14 @@ dependencies = [
  "ic-nervous-system-proto",
  "ic-nervous-system-root",
  "ic-nervous-system-runtime",
+ "ic-nervous-system-temporary",
  "ic-neurons-fund",
  "ic-nns-common",
  "ic-nns-constants",
+ "ic-nns-governance-api",
+ "ic-nns-governance-init",
  "ic-nns-gtc-accounts",
+ "ic-nns-handler-root-interface",
  "ic-protobuf",
  "ic-sns-init",
  "ic-sns-root",
@@ -3434,6 +3587,7 @@ dependencies = [
  "ic-sns-wasm",
  "ic-stable-structures",
  "ic-types",
+ "ic-utils 0.9.0",
  "icp-ledger",
  "itertools 0.12.1",
  "lazy_static",
@@ -3442,6 +3596,7 @@ dependencies = [
  "num-traits",
  "on_wire",
  "pretty_assertions",
+ "prometheus-parse",
  "prost",
  "rand",
  "rand_chacha",
@@ -3456,14 +3611,58 @@ dependencies = [
 ]
 
 [[package]]
+name = "ic-nns-governance-api"
+version = "0.9.0"
+source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
+dependencies = [
+ "bytes",
+ "candid",
+ "comparable",
+ "ic-base-types",
+ "ic-crypto-sha2",
+ "ic-nervous-system-clients",
+ "ic-nervous-system-proto",
+ "ic-nns-common",
+ "ic-protobuf",
+ "ic-sns-root",
+ "ic-sns-swap",
+ "ic-types",
+ "ic-utils 0.9.0",
+ "icp-ledger",
+ "itertools 0.12.1",
+ "prost",
+ "serde",
+ "serde_bytes",
+ "strum",
+ "strum_macros",
+]
+
+[[package]]
+name = "ic-nns-governance-init"
+version = "0.9.0"
+source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
+dependencies = [
+ "csv",
+ "ic-base-types",
+ "ic-nervous-system-common",
+ "ic-nervous-system-common-build-metadata",
+ "ic-nervous-system-common-test-keys",
+ "ic-nns-common",
+ "ic-nns-governance-api",
+ "icp-ledger",
+ "rand",
+ "rand_chacha",
+]
+
+[[package]]
 name = "ic-nns-gtc-accounts"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5849c6daf2037349bd36dcb6e26ce61c2c6570d0#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
 
 [[package]]
 name = "ic-nns-handler-root-interface"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=5849c6daf2037349bd36dcb6e26ce61c2c6570d0#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
 dependencies = [
  "async-trait",
  "candid",
@@ -3478,7 +3677,7 @@ dependencies = [
 [[package]]
 name = "ic-protobuf"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5849c6daf2037349bd36dcb6e26ce61c2c6570d0#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
 dependencies = [
  "bincode",
  "candid",
@@ -3490,9 +3689,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "ic-registry-canister-api"
+version = "0.9.0"
+source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
+dependencies = [
+ "candid",
+ "ic-base-types",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
 name = "ic-registry-keys"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5849c6daf2037349bd36dcb6e26ce61c2c6570d0#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
 dependencies = [
  "candid",
  "ic-base-types",
@@ -3502,9 +3712,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "ic-registry-node-provider-rewards"
+version = "0.9.0"
+source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
+dependencies = [
+ "ic-base-types",
+ "ic-protobuf",
+]
+
+[[package]]
 name = "ic-registry-routing-table"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5849c6daf2037349bd36dcb6e26ce61c2c6570d0#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
 dependencies = [
  "candid",
  "ic-base-types",
@@ -3515,7 +3734,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-subnet-features"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5849c6daf2037349bd36dcb6e26ce61c2c6570d0#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
 dependencies = [
  "candid",
  "ic-management-canister-types",
@@ -3526,7 +3745,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-subnet-type"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5849c6daf2037349bd36dcb6e26ce61c2c6570d0#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
 dependencies = [
  "candid",
  "ic-protobuf",
@@ -3538,7 +3757,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-transport"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5849c6daf2037349bd36dcb6e26ce61c2c6570d0#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
 dependencies = [
  "candid",
  "ic-base-types",
@@ -3550,15 +3769,18 @@ dependencies = [
 [[package]]
 name = "ic-sns-cli"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5849c6daf2037349bd36dcb6e26ce61c2c6570d0#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
 dependencies = [
  "anyhow",
  "base64 0.13.1",
  "candid",
  "clap 4.5.17",
+ "futures",
  "hex",
+ "ic-agent 0.37.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ic-base-types",
  "ic-crypto-sha2",
+ "ic-nervous-system-agent",
  "ic-nervous-system-common",
  "ic-nervous-system-common-test-keys",
  "ic-nervous-system-humanize",
@@ -3578,12 +3800,13 @@ dependencies = [
  "serde_yaml",
  "tempfile",
  "thiserror",
+ "tokio",
 ]
 
 [[package]]
 name = "ic-sns-governance"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5849c6daf2037349bd36dcb6e26ce61c2c6570d0#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
 dependencies = [
  "async-trait",
  "base64 0.13.1",
@@ -3640,7 +3863,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-governance-proposal-criticality"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=5849c6daf2037349bd36dcb6e26ce61c2c6570d0#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
 dependencies = [
  "ic-nervous-system-proto",
 ]
@@ -3648,7 +3871,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-governance-proposals-amount-total-limit"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=5849c6daf2037349bd36dcb6e26ce61c2c6570d0#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
 dependencies = [
  "ic-sns-governance-token-valuation",
  "num-traits",
@@ -3659,7 +3882,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-governance-token-valuation"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=5849c6daf2037349bd36dcb6e26ce61c2c6570d0#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
 dependencies = [
  "async-trait",
  "candid",
@@ -3680,7 +3903,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-init"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5849c6daf2037349bd36dcb6e26ce61c2c6570d0#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
 dependencies = [
  "base64 0.13.1",
  "candid",
@@ -3707,7 +3930,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-root"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5849c6daf2037349bd36dcb6e26ce61c2c6570d0#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
 dependencies = [
  "async-trait",
  "build-info",
@@ -3736,7 +3959,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-swap"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5849c6daf2037349bd36dcb6e26ce61c2c6570d0#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
 dependencies = [
  "async-trait",
  "build-info",
@@ -3774,7 +3997,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-swap-proto-library"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=5849c6daf2037349bd36dcb6e26ce61c2c6570d0#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
 dependencies = [
  "candid",
  "comparable",
@@ -3789,7 +4012,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-wasm"
 version = "1.0.0"
-source = "git+https://github.com/dfinity/ic?rev=5849c6daf2037349bd36dcb6e26ce61c2c6570d0#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
 dependencies = [
  "async-trait",
  "candid",
@@ -3816,7 +4039,6 @@ dependencies = [
  "ic-utils 0.9.0",
  "ic-wasm",
  "icrc-ledger-types",
- "libflate 1.4.0",
  "maplit",
  "prost",
  "serde",
@@ -3831,6 +4053,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03f3044466a69802de74e710dc0300b706a05696a0531c942ca856751a13b0db"
 dependencies = [
  "ic_principal",
+]
+
+[[package]]
+name = "ic-transport-types"
+version = "0.37.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875dc4704780383112e8e8b5063a1b98de114321d0c7d3e7f635dcf360a57fba"
+dependencies = [
+ "candid",
+ "hex",
+ "ic-certification",
+ "leb128",
+ "serde",
+ "serde_bytes",
+ "serde_repr",
+ "sha2 0.10.8",
+ "thiserror",
 ]
 
 [[package]]
@@ -3852,7 +4091,7 @@ dependencies = [
 [[package]]
 name = "ic-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5849c6daf2037349bd36dcb6e26ce61c2c6570d0#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
 dependencies = [
  "base64 0.13.1",
  "bincode",
@@ -3860,7 +4099,7 @@ dependencies = [
  "chrono",
  "hex",
  "ic-base-types",
- "ic-btc-types-internal",
+ "ic-btc-replica-types",
  "ic-constants",
  "ic-crypto-internal-types",
  "ic-crypto-sha2",
@@ -3869,6 +4108,8 @@ dependencies = [
  "ic-management-canister-types",
  "ic-protobuf",
  "ic-utils 0.9.0",
+ "ic-validate-eq",
+ "ic-validate-eq-derive",
  "maplit",
  "once_cell",
  "phantom_newtype",
@@ -3887,7 +4128,7 @@ dependencies = [
 [[package]]
 name = "ic-utils"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5849c6daf2037349bd36dcb6e26ce61c2c6570d0#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
 dependencies = [
  "hex",
  "scoped_threadpool",
@@ -3903,7 +4144,7 @@ dependencies = [
  "async-trait",
  "candid",
  "futures-util",
- "ic-agent",
+ "ic-agent 0.37.1 (git+https://github.com/dfinity/agent-rs?rev=6e11a350112f9b907c4d590d8217f340e153d898)",
  "once_cell",
  "semver",
  "serde",
@@ -3917,29 +4158,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "ic-validate-eq"
+version = "0.0.0"
+source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
+dependencies = [
+ "ic-validate-eq-derive",
+]
+
+[[package]]
+name = "ic-validate-eq-derive"
+version = "0.0.0"
+source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
+dependencies = [
+ "darling 0.20.10",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "ic-verify-bls-signature"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d420b25c0091059f6c3c23a21427a81915e6e0aca3b79e0d403ed767f286a3b9"
 dependencies = [
  "hex",
- "ic_bls12_381 0.10.0",
+ "ic_bls12_381",
  "lazy_static",
- "pairing 0.23.0",
+ "pairing",
  "rand",
  "sha2 0.10.8",
 ]
 
 [[package]]
 name = "ic-wasm"
-version = "0.7.2"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1f3f1ec63f08807d176691225de0b993e832b1fff71c631ed897df5888c7be4"
+checksum = "5574bf249d201ddd2c27c3fdf178ddacb1be1c705c8a5b4c1339c393758f2bf2"
 dependencies = [
  "anyhow",
  "candid",
  "clap 4.5.17",
- "libflate 2.1.0",
+ "libflate",
  "rustc-demangle",
  "serde",
  "serde_json",
@@ -3971,21 +4231,6 @@ checksum = "a54b5297861c651551676e8c43df805dad175cc33bc97dbd992edbbb85dcbcdf"
 
 [[package]]
 name = "ic_bls12_381"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c682cb199cd8fcb582a6023325d571a6464edda26c8063fe04b6f6082a1a363c"
-dependencies = [
- "digest 0.9.0",
- "ff 0.12.1",
- "group 0.12.1",
- "pairing 0.22.0",
- "rand_core",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "ic_bls12_381"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22c65787944f32af084dffd0c68c1e544237b76e215654ddea8cd9f527dd8b69"
@@ -3993,9 +4238,10 @@ dependencies = [
  "digest 0.10.7",
  "ff 0.13.0",
  "group 0.13.0",
- "pairing 0.23.0",
+ "pairing",
  "rand_core",
  "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -4014,7 +4260,7 @@ dependencies = [
 [[package]]
 name = "icp-ledger"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5849c6daf2037349bd36dcb6e26ce61c2c6570d0#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
 dependencies = [
  "candid",
  "comparable",
@@ -4034,7 +4280,6 @@ dependencies = [
  "num-traits",
  "on_wire",
  "prost",
- "prost-derive",
  "serde",
  "serde_bytes",
  "serde_cbor",
@@ -4045,7 +4290,7 @@ dependencies = [
 [[package]]
 name = "icrc-ledger-client"
 version = "0.1.2"
-source = "git+https://github.com/dfinity/ic?rev=5849c6daf2037349bd36dcb6e26ce61c2c6570d0#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
 dependencies = [
  "async-trait",
  "candid",
@@ -4055,8 +4300,8 @@ dependencies = [
 
 [[package]]
 name = "icrc-ledger-types"
-version = "0.1.5"
-source = "git+https://github.com/dfinity/ic?rev=5849c6daf2037349bd36dcb6e26ce61c2c6570d0#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+version = "0.1.6"
+source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
 dependencies = [
  "base32",
  "candid",
@@ -4069,6 +4314,125 @@ dependencies = [
  "serde_bytes",
  "sha2 0.10.8",
  "strum",
+ "time",
+]
+
+[[package]]
+name = "icu_collections"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid_transform"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01d11ac35de8e40fdeda00d9e1e9d92525f3f9d887cdd7aa81d727596788b54e"
+dependencies = [
+ "displaydoc",
+ "icu_locid",
+ "icu_locid_transform_data",
+ "icu_provider",
+ "tinystr",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid_transform_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdc8ff3388f852bede6b579ad4e978ab004f139284d7b28715f773507b946f6e"
+
+[[package]]
+name = "icu_normalizer"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19ce3e0da2ec68599d193c93d088142efd7f9c5d6fc9b803774855747dc6a84f"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "utf16_iter",
+ "utf8_iter",
+ "write16",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8cafbf7aa791e9b22bec55a167906f9e1215fd475cd22adfcf660e03e989516"
+
+[[package]]
+name = "icu_properties"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93d6020766cfc6302c15dbbc9c8778c37e62c14427cb7f6e601d849e092aeef5"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_locid_transform",
+ "icu_properties_data",
+ "icu_provider",
+ "tinystr",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67a8effbc3dd3e4ba1afa8ad918d5684b8868b3b26500753effea8d2eed19569"
+
+[[package]]
+name = "icu_provider"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ed421c8a8ef78d3e2dbc98a973be2f3770cb42b606e3ab18d6237c4dfde68d9"
+dependencies = [
+ "displaydoc",
+ "icu_locid",
+ "icu_provider_macros",
+ "stable_deref_trait",
+ "tinystr",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_provider_macros"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -4094,6 +4458,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "idna"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd69211b9b519e98303c015e21a007e293db403b6c85b9b124e133d25e242cdd"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4111,6 +4487,7 @@ checksum = "68b900aa2f7301e21c36462b170ee99994de34dff39a4a6a528e80e7376d07e5"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.5",
+ "serde",
 ]
 
 [[package]]
@@ -4301,17 +4678,6 @@ checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
 
 [[package]]
 name = "libflate"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ff4ae71b685bbad2f2f391fe74f6b7659a34871c08b210fdc039e43bee07d18"
-dependencies = [
- "adler32",
- "crc32fast",
- "libflate_lz77 1.2.0",
-]
-
-[[package]]
-name = "libflate"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45d9dfdc14ea4ef0900c1cddbc8dcd553fbaacd8a4a282cf4018ae9dd04fb21e"
@@ -4320,16 +4686,7 @@ dependencies = [
  "core2",
  "crc32fast",
  "dary_heap",
- "libflate_lz77 2.1.0",
-]
-
-[[package]]
-name = "libflate_lz77"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a52d3a8bfc85f250440e4424db7d857e241a3aebbbe301f3eb606ab15c39acbf"
-dependencies = [
- "rle-decode-fast",
+ "libflate_lz77",
 ]
 
 [[package]]
@@ -4391,6 +4748,12 @@ name = "linux-raw-sys"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
+
+[[package]]
+name = "litemap"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "643cb0b8d4fcc284004d5fd0d67ccf61dfffadb7f75e1e71bc420f4688a3a704"
 
 [[package]]
 name = "lock_api"
@@ -4496,14 +4859,13 @@ dependencies = [
 
 [[package]]
 name = "mockall"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43766c2b5203b10de348ffe19f7e54564b64f3d6018ff7648d1e2d6d3a0f0a48"
+checksum = "d4c28b3fb6d753d28c20e826cd46ee611fda1cf3cde03a443a974043247c065a"
 dependencies = [
  "cfg-if",
  "downcast",
  "fragile",
- "lazy_static",
  "mockall_derive",
  "predicates",
  "predicates-tree",
@@ -4511,9 +4873,9 @@ dependencies = [
 
 [[package]]
 name = "mockall_derive"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af7cbce79ec385a1d4f54baa90a76401eb15d9cab93685f62e7e9f942aa00ae2"
+checksum = "341014e7f530314e9a1fdbc7400b244efea7122662c96bfa248c31da5bfb2020"
 dependencies = [
  "cfg-if",
  "proc-macro2",
@@ -4581,7 +4943,7 @@ dependencies = [
  "fn-error-context",
  "futures-util",
  "hex",
- "ic-agent",
+ "ic-agent 0.37.1 (git+https://github.com/dfinity/agent-rs?rev=6e11a350112f9b907c4d590d8217f340e153d898)",
  "ic-icp-index",
  "ic-icrc1-index-ng",
  "ic-icrc1-ledger",
@@ -4736,7 +5098,7 @@ dependencies = [
 [[package]]
 name = "on_wire"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5849c6daf2037349bd36dcb6e26ce61c2c6570d0#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
 
 [[package]]
 name = "once_cell"
@@ -4820,15 +5182,6 @@ dependencies = [
  "elliptic-curve 0.13.8",
  "primeorder",
  "sha2 0.10.8",
-]
-
-[[package]]
-name = "pairing"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "135590d8bdba2b31346f9cd1fb2a912329f5135e832a4f422942eb6ead8b6b3b"
-dependencies = [
- "group 0.12.1",
 ]
 
 [[package]]
@@ -4996,7 +5349,7 @@ dependencies = [
 [[package]]
 name = "phantom_newtype"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5849c6daf2037349bd36dcb6e26ce61c2c6570d0#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
 dependencies = [
  "candid",
  "serde",
@@ -5258,6 +5611,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "prometheus-parse"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "811031bea65e5a401fb2e1f37d802cca6601e204ac463809a3189352d13b78a5"
+dependencies = [
+ "chrono",
+ "itertools 0.12.1",
+ "once_cell",
+ "regex",
+]
+
+[[package]]
 name = "prost"
 version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5490,7 +5855,7 @@ checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 [[package]]
 name = "registry-canister"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5849c6daf2037349bd36dcb6e26ce61c2c6570d0#5849c6daf2037349bd36dcb6e26ce61c2c6570d0"
+source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
 dependencies = [
  "build-info",
  "build-info-build",
@@ -5513,12 +5878,15 @@ dependencies = [
  "ic-nns-common",
  "ic-nns-constants",
  "ic-protobuf",
+ "ic-registry-canister-api",
  "ic-registry-keys",
+ "ic-registry-node-provider-rewards",
  "ic-registry-routing-table",
  "ic-registry-subnet-features",
  "ic-registry-subnet-type",
  "ic-registry-transport",
  "ic-types",
+ "idna 1.0.2",
  "ipnet",
  "lazy_static",
  "leb128",
@@ -5548,7 +5916,7 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2",
+ "h2 0.3.26",
  "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.30",
@@ -6177,7 +6545,7 @@ version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e182d6ec6f05393cc0e5ed1bf81ad6db3a8feedf8ee515ecdd369809bcce8082"
 dependencies = [
- "darling",
+ "darling 0.13.4",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -6241,6 +6609,15 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "signature"
@@ -6349,6 +6726,7 @@ dependencies = [
  "dfx-extensions-utils",
  "fn-error-context",
  "futures-util",
+ "ic-agent 0.37.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ic-sns-cli",
  "serde_json",
  "slog",
@@ -6714,6 +7092,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinystr"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6738,9 +7126,23 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
+ "parking_lot",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2 0.5.7",
+ "tokio-macros",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -6848,6 +7250,7 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -6868,6 +7271,7 @@ version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-core",
 ]
@@ -6982,16 +7386,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22784dbdf76fdde8af1aeda5622b546b422b6fc585325248a2bf9f5e41e94d6c"
 dependencies = [
  "form_urlencoded",
- "idna",
+ "idna 0.5.0",
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "utf16_iter"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
 
 [[package]]
 name = "utf8-width"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86bd8d4e895da8537e5315b8254664e6b769c4ff3db18321b297a1e7004392e3"
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utf8parse"
@@ -7025,9 +7441,9 @@ checksum = "317211a0dc0ceedd78fb2ca9a44aed3d7b9b26f81870d485c07122b4350673b7"
 
 [[package]]
 name = "walrus"
-version = "0.20.3"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c03529cd0c4400a2449f640d2f27cd1b48c3065226d15e26d98e4429ab0adb7"
+checksum = "160c3708e3ad718ab4d84bec8de8c3d3450cd2902bd6c3ee3bbf50ad7529c2ad"
 dependencies = [
  "anyhow",
  "gimli 0.26.2",
@@ -7135,9 +7551,9 @@ checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
 
 [[package]]
 name = "wasm-encoder"
-version = "0.29.0"
+version = "0.212.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18c41dbd92eaebf3612a39be316540b8377c871cb9bde6b064af962984912881"
+checksum = "501940df4418b8929eb6d52f1aade1fdd15a5b86c92453cb696e3c906bd3fc33"
 dependencies = [
  "leb128",
 ]
@@ -7157,9 +7573,17 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.80.2"
+version = "0.212.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "449167e2832691a1bff24cde28d2804e90e09586a448c8e76984792c44334a6b"
+checksum = "8d28bc49ba1e5c5b61ffa7a2eace10820443c4b7d1c0b144109261d14570fdf8"
+dependencies = [
+ "ahash 0.8.11",
+ "bitflags 2.6.0",
+ "hashbrown 0.14.5",
+ "indexmap 2.5.0",
+ "semver",
+ "serde",
+]
 
 [[package]]
 name = "web-sys"
@@ -7452,6 +7876,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "write16"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
+
+[[package]]
+name = "writeable"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
+
+[[package]]
 name = "wyz"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7502,6 +7938,30 @@ name = "yansi"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
+
+[[package]]
+name = "yoke"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c5b1314b079b0930c31e3af543d8ee1757b1951ae1e1565ec704403a7240ca5"
+dependencies = [
+ "serde",
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28cc31741b18cb6f1d5ff12f5b7523e3d6eb0852bbbad19d73905511d9849b95"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.77",
+ "synstructure",
+]
 
 [[package]]
 name = "zbus"
@@ -7560,6 +8020,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "zerofrom"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91ec111ce797d0e0784a1116d0ddcdbea84322cd79e5d5ad173daeba4f93ab55"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ea7b4a3637ea8669cedf0f1fd5c286a17f3de97b8dd5a70a6c167a1730e63a5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.77",
+ "synstructure",
+]
+
+[[package]]
 name = "zeroize"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7573,6 +8054,28 @@ name = "zeroize_derive"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.77",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa2b893d79df23bfb12d5461018d408ea19dfafe76c2c7ef6d4eba614f8ff079"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,18 +4,12 @@ version = 3
 
 [[package]]
 name = "addr2line"
-version = "0.22.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e4503c46a5c0c7844e948c9a4d6acd9f50cccb4de1c48eb9e291ea17470c678"
+checksum = "f5fb1d8e4442bd405fdfd1dacb42792696b0cf9cb15882e5d097b742a676d375"
 dependencies = [
- "gimli 0.29.0",
+ "gimli 0.31.0",
 ]
-
-[[package]]
-name = "adler"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "adler2"
@@ -180,9 +174,15 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.87"
+version = "1.0.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10f00e1f6e58a40e807377c75c6a7f97bf9044fab57816f2414e6f5f4499d7b8"
+checksum = "4e1496f8fb1fbf272686b8d37f523dab3e4a7443300055e74cdaa449f3114356"
+
+[[package]]
+name = "arc-swap"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
 
 [[package]]
 name = "argon2"
@@ -336,17 +336,17 @@ dependencies = [
 
 [[package]]
 name = "backtrace"
-version = "0.3.73"
+version = "0.3.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cc23269a4f8976d0a4d2e7109211a419fe30e8d88d677cd60b6bc79c5732e0a"
+checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
 dependencies = [
  "addr2line",
- "cc",
  "cfg-if",
  "libc",
- "miniz_oxide 0.7.4",
+ "miniz_oxide",
  "object",
  "rustc-demangle",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -753,6 +753,8 @@ version = "1.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b62ac837cdb5cb22e10a256099b4fc502b1dfe560cb282963a974d7abd80e476"
 dependencies = [
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -1179,6 +1181,15 @@ dependencies = [
  "rand_core",
  "subtle-ng",
  "zeroize",
+]
+
+[[package]]
+name = "cvt"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2ae9bf77fbf2d39ef573205d554d87e86c12f1994e9ea335b0651b9b278bcf1"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -1889,7 +1900,7 @@ checksum = "324a1be68054ef05ad64b861cc9eaf1d623d2d8cb25b4bf2cb9cdd902b4bf253"
 dependencies = [
  "crc32fast",
  "libz-ng-sys",
- "miniz_oxide 0.8.0",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -2094,9 +2105,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.29.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
+checksum = "32085ea23f3234fc7846555e85283ba4de91e21016dc0455a16286d87a292d64"
 
 [[package]]
 name = "glob"
@@ -2458,7 +2469,7 @@ dependencies = [
  "hyper 0.14.30",
  "log",
  "rustls 0.20.9",
- "rustls-native-certs",
+ "rustls-native-certs 0.6.3",
  "tokio",
  "tokio-rustls 0.23.4",
  "webpki-roots 0.22.6",
@@ -2488,7 +2499,8 @@ dependencies = [
  "http 1.1.0",
  "hyper 1.4.1",
  "hyper-util",
- "rustls 0.23.12",
+ "rustls 0.23.13",
+ "rustls-native-certs 0.8.0",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.0",
@@ -2511,9 +2523,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cde7055719c54e36e95e8719f95883f22072a48ede39db7fc17a4e1d5281e9b9"
+checksum = "da62f120a8a37763efb0cf8fdf264b884c7b8b9ac8660b900c8661030c00e6ba"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -2584,7 +2596,7 @@ dependencies = [
  "rangemap",
  "reqwest 0.12.7",
  "ring 0.17.8",
- "rustls-webpki 0.102.7",
+ "rustls-webpki 0.102.8",
  "sec1 0.7.3",
  "serde",
  "serde_bytes",
@@ -2625,7 +2637,7 @@ dependencies = [
  "rangemap",
  "reqwest 0.12.7",
  "ring 0.17.8",
- "rustls-webpki 0.102.7",
+ "rustls-webpki 0.102.8",
  "sec1 0.7.3",
  "serde",
  "serde_bytes",
@@ -2796,6 +2808,21 @@ dependencies = [
  "serde",
  "serde_bytes",
  "sha2 0.10.8",
+]
+
+[[package]]
+name = "ic-config"
+version = "0.9.0"
+source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
+dependencies = [
+ "ic-base-types",
+ "ic-protobuf",
+ "ic-registry-subnet-type",
+ "ic-sys",
+ "ic-types",
+ "json5",
+ "serde",
+ "tempfile",
 ]
 
 [[package]]
@@ -3106,6 +3133,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "ic-http-utils"
+version = "0.9.0"
+source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
+dependencies = [
+ "flate2",
+ "hex",
+ "http 1.1.0",
+ "ic-crypto-sha2",
+ "ic-logger",
+ "reqwest 0.12.7",
+ "slog",
+ "tar",
+ "tokio",
+ "zstd",
+]
+
+[[package]]
 name = "ic-icp-index"
 version = "0.9.0"
 source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
@@ -3275,6 +3319,23 @@ dependencies = [
  "candid",
  "hex",
  "serde",
+]
+
+[[package]]
+name = "ic-logger"
+version = "0.9.0"
+source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
+dependencies = [
+ "chrono",
+ "ic-config",
+ "ic-protobuf",
+ "ic-utils 0.9.0",
+ "serde",
+ "slog",
+ "slog-async",
+ "slog-json",
+ "slog-scope",
+ "slog-term",
 ]
 
 [[package]]
@@ -4056,6 +4117,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "ic-sys"
+version = "0.9.0"
+source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
+dependencies = [
+ "cvt",
+ "hex",
+ "ic-crypto-sha2",
+ "lazy_static",
+ "libc",
+ "nix 0.24.3",
+ "phantom_newtype",
+ "prost",
+ "rand",
+ "thiserror",
+ "tokio",
+ "wsl",
+]
+
+[[package]]
 name = "ic-transport-types"
 version = "0.37.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4521,9 +4601,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
+checksum = "187674a687eed5fe42285b40c6291f9a01517d415fad1c3cbc6a9f778af7fcd4"
 
 [[package]]
 name = "is-terminal"
@@ -4575,6 +4655,15 @@ name = "itoa"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
+
+[[package]]
+name = "jobserver"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "js-sys"
@@ -4822,19 +4911,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
-
-[[package]]
-name = "miniz_oxide"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08"
-dependencies = [
- "adler",
-]
 
 [[package]]
 name = "miniz_oxide"
@@ -4930,6 +5020,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.24.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa52e972a9a719cecb6864fb88568781eb706bac2cd1d4f04a648542dbf78069"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
+ "memoffset",
+]
+
+[[package]]
 name = "nns"
 version = "0.4.3"
 dependencies = [
@@ -4944,6 +5046,7 @@ dependencies = [
  "futures-util",
  "hex",
  "ic-agent 0.37.1 (git+https://github.com/dfinity/agent-rs?rev=6e11a350112f9b907c4d590d8217f340e153d898)",
+ "ic-http-utils",
  "ic-icp-index",
  "ic-icrc1-index-ng",
  "ic-icrc1-ledger",
@@ -5195,9 +5298,9 @@ dependencies = [
 
 [[package]]
 name = "parking"
-version = "2.2.0"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb813b8af86854136c6922af0598d719255ecb2179515e6e7730d468f05c9cae"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -5715,7 +5818,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash 2.0.0",
- "rustls 0.23.12",
+ "rustls 0.23.13",
  "socket2 0.5.7",
  "thiserror",
  "tokio",
@@ -5732,7 +5835,7 @@ dependencies = [
  "rand",
  "ring 0.17.8",
  "rustc-hash 2.0.0",
- "rustls 0.23.12",
+ "rustls 0.23.13",
  "slab",
  "thiserror",
  "tinyvec",
@@ -5805,9 +5908,9 @@ checksum = "f60fcc7d6849342eff22c4350c8b9a989ee8ceabc4b481253e8946b9fe83d684"
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a908a6e00f1fdd0dfd9c0eb08ce85126f6d8bbda50017e74bc4a4b7d4a926a4"
+checksum = "0884ad60e090bf1345b93da0a5de8923c93884cd03f40dfcfddd3b4bee661853"
 dependencies = [
  "bitflags 2.6.0",
 ]
@@ -5960,6 +6063,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
+ "h2 0.4.6",
  "http 1.1.0",
  "http-body 1.0.1",
  "http-body-util",
@@ -5970,11 +6074,13 @@ dependencies = [
  "js-sys",
  "log",
  "mime",
+ "mime_guess",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.12",
+ "rustls 0.23.13",
+ "rustls-native-certs 0.7.3",
  "rustls-pemfile 2.1.3",
  "rustls-pki-types",
  "serde",
@@ -5983,6 +6089,7 @@ dependencies = [
  "sync_wrapper 1.0.1",
  "tokio",
  "tokio-rustls 0.26.0",
+ "tokio-socks",
  "tokio-util",
  "tower-service",
  "url",
@@ -6167,9 +6274,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.36"
+version = "0.38.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f55e80d50763938498dd5ebb18647174e0c76dc38c5505294bb224624f30f36"
+checksum = "8acb788b847c24f28525660c4d7758620a7210875711f79e7f663cc152726811"
 dependencies = [
  "bitflags 2.6.0",
  "errno",
@@ -6204,14 +6311,14 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.12"
+version = "0.23.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c58f8c84392efc0a126acce10fa59ff7b3d2ac06ab451a33f2741989b806b044"
+checksum = "f2dabaac7466917e566adb06783a81ca48944c6898a1b08b9374106dd671f4c8"
 dependencies = [
  "once_cell",
  "ring 0.17.8",
  "rustls-pki-types",
- "rustls-webpki 0.102.7",
+ "rustls-webpki 0.102.8",
  "subtle",
  "zeroize",
 ]
@@ -6224,6 +6331,32 @@ checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
 dependencies = [
  "openssl-probe",
  "rustls-pemfile 1.0.4",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile 2.1.3",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcaf18a4f2be7326cd874a5fa579fae794320a0f388d365dca7e480e55f83f8a"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile 2.1.3",
+ "rustls-pki-types",
  "schannel",
  "security-framework",
 ]
@@ -6265,9 +6398,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.102.7"
+version = "0.102.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84678086bd54edf2b415183ed7a94d0efb049f1b646a33e22a36f3794be6ae56"
+checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
 dependencies = [
  "ring 0.17.8",
  "rustls-pki-types",
@@ -6688,6 +6821,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "slog-json"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e1e53f61af1e3c8b852eef0a9dee29008f55d6dd63794f3f12cef786cf0f219"
+dependencies = [
+ "erased-serde",
+ "serde",
+ "serde_json",
+ "slog",
+ "time",
+]
+
+[[package]]
+name = "slog-scope"
+version = "4.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f95a4b4c3274cd2869549da82b57ccc930859bdbf5bcea0424bc5f140b3c786"
+dependencies = [
+ "arc-swap",
+ "lazy_static",
+ "slog",
+]
+
+[[package]]
 name = "slog-term"
 version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6951,9 +7108,9 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tar"
-version = "0.4.41"
+version = "0.4.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb797dad5fb5b76fcf519e702f4a589483b5ef06567f160c392832c1f5e44909"
+checksum = "ec96d2ffad078296368d46ff1cb309be1c23c513b4ab0e22a45de0185275ac96"
 dependencies = [
  "filetime",
  "libc",
@@ -6969,7 +7126,7 @@ dependencies = [
  "cfg-if",
  "fastrand 2.1.1",
  "once_cell",
- "rustix 0.38.36",
+ "rustix 0.38.37",
  "windows-sys 0.59.0",
 ]
 
@@ -7182,8 +7339,20 @@ version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
 dependencies = [
- "rustls 0.23.12",
+ "rustls 0.23.13",
  "rustls-pki-types",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-socks"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d4770b8024672c1101b3f6733eab95b18007dbe0847a8afe341fcf79e06043f"
+dependencies = [
+ "either",
+ "futures-util",
+ "thiserror",
  "tokio",
 ]
 
@@ -7319,6 +7488,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
 
 [[package]]
+name = "unicase"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7d2d4dafb69621809a81864c9c1b864479e1235c0dd4e199924b9742439ed89"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
 name = "unicode-bidi"
 version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7326,9 +7504,9 @@ checksum = "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.12"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
 
 [[package]]
 name = "unicode-normalization"
@@ -7888,6 +8066,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
 
 [[package]]
+name = "wsl"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dab7ac864710bdea6594becbea5b5050333cf34fefb0dc319567eb347950d4"
+
+[[package]]
 name = "wyz"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7915,13 +8099,11 @@ dependencies = [
 
 [[package]]
 name = "xattr"
-version = "1.3.1"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8da84f1a25939b27f6820d92aed108f83ff920fdf11a7b19366c27c4cda81d4f"
+checksum = "6d1526bbe5aaeb5eb06885f4d987bcdfa5e23187055de9b83fe00156a821fabc"
 dependencies = [
  "libc",
- "linux-raw-sys 0.4.14",
- "rustix 0.38.36",
 ]
 
 [[package]]
@@ -7976,7 +8158,7 @@ dependencies = [
  "fastrand 1.9.0",
  "futures",
  "nb-connect",
- "nix",
+ "nix 0.22.3",
  "once_cell",
  "polling",
  "scoped-tls",
@@ -8080,6 +8262,34 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.77",
+]
+
+[[package]]
+name = "zstd"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcf2b778a664581e31e389454a7072dab1647606d44f7feea22cd5abb9c9f3f9"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54a3ab4db68cea366acc5c897c7b4d4d1b8994a9cd6e6f841f8964566a419059"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.13+zstd.1.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38ff0f21cfee8f97d94cef41359e0c89aa6113028ab0291aa8ca0038995a95aa"
+dependencies = [
+ "cc",
+ "pkg-config",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ slog = "^2.7.0"
 tempfile = "3.12.0"
 tokio = { version = "^1.36.0", features = ["rt-multi-thread"] }
 url = "^2.4.1"
+ic-http-utils = { git = "https://github.com/dfinity/ic", rev = "5ff84f5b82fc675683d6b70c4e1a81678813633a" }
 ic-icp-index = { git = "https://github.com/dfinity/ic", rev = "5ff84f5b82fc675683d6b70c4e1a81678813633a" }
 ic-icrc1-index-ng = { git = "https://github.com/dfinity/ic", rev = "5ff84f5b82fc675683d6b70c4e1a81678813633a" }
 ic-icrc1-ledger = { git = "https://github.com/dfinity/ic", rev = "5ff84f5b82fc675683d6b70c4e1a81678813633a" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,13 +31,13 @@ reqwest = { version = "^0.11.22", default-features = false, features = [
 ] }
 serde = "^1.0"
 slog = "^2.7.0"
-tempfile = "3.5.0"
+tempfile = "3"
 tokio = { version = "^1.36.0", features = ["rt-multi-thread"] }
 url = "^2.4.1"
-ic-icp-index = { git = "https://github.com/dfinity/ic", rev = "5849c6daf2037349bd36dcb6e26ce61c2c6570d0" }
-ic-icrc1-index-ng = { git = "https://github.com/dfinity/ic", rev = "5849c6daf2037349bd36dcb6e26ce61c2c6570d0" }
-ic-icrc1-ledger = { git = "https://github.com/dfinity/ic", rev = "5849c6daf2037349bd36dcb6e26ce61c2c6570d0" }
-ic-sns-cli = { git = "https://github.com/dfinity/ic", rev = "5849c6daf2037349bd36dcb6e26ce61c2c6570d0" }
+ic-icp-index = { git = "https://github.com/dfinity/ic", rev = "5ff84f5b82fc675683d6b70c4e1a81678813633a" }
+ic-icrc1-index-ng = { git = "https://github.com/dfinity/ic", rev = "5ff84f5b82fc675683d6b70c4e1a81678813633a" }
+ic-icrc1-ledger = { git = "https://github.com/dfinity/ic", rev = "5ff84f5b82fc675683d6b70c4e1a81678813633a" }
+ic-sns-cli = { git = "https://github.com/dfinity/ic", rev = "5ff84f5b82fc675683d6b70c4e1a81678813633a" }
 serde_json = "1.0.79"
 
 # Config for 'cargo dist'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ reqwest = { version = "^0.11.22", default-features = false, features = [
 ] }
 serde = "^1.0"
 slog = "^2.7.0"
-tempfile = "3"
+tempfile = "3.12.0"
 tokio = { version = "^1.36.0", features = ["rt-multi-thread"] }
 url = "^2.4.1"
 ic-icp-index = { git = "https://github.com/dfinity/ic", rev = "5ff84f5b82fc675683d6b70c4e1a81678813633a" }

--- a/extensions/nns/Cargo.toml
+++ b/extensions/nns/Cargo.toml
@@ -28,6 +28,7 @@ futures-util.workspace = true
 ic-icp-index.workspace = true
 ic-icrc1-index-ng.workspace = true
 ic-icrc1-ledger.workspace = true
+ic-http-utils.workspace = true
 hex = "0.4.3"
 reqwest.workspace = true
 rust_decimal = "1.29.1"

--- a/extensions/nns/build.rs
+++ b/extensions/nns/build.rs
@@ -1,7 +1,7 @@
 use std::env;
 use std::path::PathBuf;
 
-const REPLICA_REV: &str = "cc4ea40e8571b80043013e4e74bd2b89844230c7";
+const REPLICA_REV: &str = "5ff84f5b82fc675683d6b70c4e1a81678813633a";
 
 const BINARY_DEPENDENCIES: &[(&str, &str)] = &[
     // (downloaded binary name, renamed binary name)

--- a/extensions/nns/src/install_nns.rs
+++ b/extensions/nns/src/install_nns.rs
@@ -631,6 +631,8 @@ pub fn set_cycles_ledger_canister_id_in_cmc(
     let cmc_wasm_path_str = cmc_wasm_path.to_string_lossy();
     let wasm_hash_str = hex::encode(wasm_hash);
     let upgrade_arg_file_str = upgrade_arg_file.path().to_string_lossy();
+    let upgrade_arg_hash =
+        ic_http_utils::file_downloader::compute_sha256_hex(&upgrade_arg_file.path())?;
     let args = vec![
         "--nns-url",
         nns_url.as_str(),
@@ -650,6 +652,8 @@ pub fn set_cycles_ledger_canister_id_in_cmc(
         &wasm_hash_str,
         "--arg",
         &upgrade_arg_file_str,
+        "--arg-sha256",
+        &upgrade_arg_hash,
     ];
     call_extension_bundled_binary("ic-admin", args, dfx_cache_path)
         .map_err(|e| anyhow!("Call to set the cycles ledger canister id in the CMC: {e}"))

--- a/extensions/nns/src/install_nns.rs
+++ b/extensions/nns/src/install_nns.rs
@@ -670,7 +670,7 @@ pub fn upload_nns_sns_wasms_canister_wasms(dfx_cache_path: &Path) -> anyhow::Res
             canister_type: upload_name.to_string(),
             override_sns_wasm_canister_id_for_tests: Some(NNS_SNS_WASM.canister_id.into()),
             network: "local".to_string(),
-        });
+        })?;
     }
     Ok(())
 }

--- a/extensions/sns/Cargo.toml
+++ b/extensions/sns/Cargo.toml
@@ -21,6 +21,7 @@ anyhow.workspace = true
 clap.workspace = true
 fn-error-context.workspace = true
 slog.workspace = true
+ic-agent = "0.37"
 tokio.workspace = true
 futures-util = "0.3.28"
 candid.workspace = true

--- a/extensions/sns/README.md
+++ b/extensions/sns/README.md
@@ -16,6 +16,7 @@ Depending on the `dfx sns` subcommand you specify, additional arguments, options
 | [`prepare-canisters`](#_dfx_sns_prepare-canisters)                 | Prepares dapp canister(s) for SNS decentralization by adding NNS root as one of their controllers.                 |
 | [`propose`](#_dfx_sns_propose)                                     | Submits a CreateServiceNervousSystem NNS Proposal.                                                                 |
 | [`neuron-id-to-candid-subaccount`](#_dfx_sns_propose)              | Converts a Neuron ID to a candid subaccount blob suitable for use in the `manage_neuron` method on SNS Governance. |
+| [`list`](#_list)                                                   | Lists SNSes and their canister IDs.                                                                                |
 | `help`                                                             | Displays usage information message for a specified subcommand.                                                     |
 
 To view usage information for a specific subcommand, specify the subcommand and the `--help` flag. For example, to see usage information for `dfx sns validate`, you can run the following command:
@@ -105,4 +106,14 @@ to the local dfx server. If this flag is used when submitting to mainnet, the re
 
 ```
 dfx sns propose --test-neuron-proposer sns_init.yaml
+```
+
+## dfx sns list
+
+Use the `dfx sns list` command to see all the SNSes and their canister IDs. You can also pass --json to get this information in json format rather than a human-readable table.
+
+### Basic usage
+
+``` bash
+dfx sns list
 ```

--- a/extensions/sns/build.rs
+++ b/extensions/sns/build.rs
@@ -1,7 +1,7 @@
 use std::env;
 use std::path::PathBuf;
 
-const REPLICA_REV: &str = "cc4ea40e8571b80043013e4e74bd2b89844230c7";
+const REPLICA_REV: &str = "5ff84f5b82fc675683d6b70c4e1a81678813633a";
 
 const BINARY_DEPENDENCIES: &[(&str, &str)] = &[
     // (downloaded binary name, renamed binary name)

--- a/extensions/sns/e2e/tests/sns.bash
+++ b/extensions/sns/e2e/tests/sns.bash
@@ -69,8 +69,6 @@ SNS_CONFIG_FILE_NAME="sns_init.yaml"
     dfx nns install
     echo "===== 7 ====="
     dfx nns import
-    echo "===== 8 ====="
-    dfx sns import
     echo "===== 9 ====="
     ls candid
     echo "===== 10 ====="

--- a/extensions/sns/e2e/tests/sns.bash
+++ b/extensions/sns/e2e/tests/sns.bash
@@ -55,19 +55,32 @@ SNS_CONFIG_FILE_NAME="sns_init.yaml"
 }
 
 @test "sns propose succeeds" {
+    echo "===== 1 ====="
     dfx_extension_install_manually nns
+    echo "===== 2 ====="
     dfx_new
+    echo "===== 3 ====="
     install_shared_asset subnet_type/shared_network_settings/system
+    echo "===== 4 ====="
     dfx start --clean --background --host 127.0.0.1:8080
+    echo "===== 5 ====="
     wait_until_replica_healthy
+    echo "===== 6 ====="
     dfx nns install
+    echo "===== 7 ====="
     dfx nns import
+    echo "===== 8 ====="
     dfx sns import
+    echo "===== 9 ====="
     ls candid
+    echo "===== 10 ====="
     cat dfx.json
+    echo "===== 11 ====="    
     # Deploy the SNS
     install_asset sns/valid
+    echo "===== 12 ====="
     dfx sns init-config-file validate
+    echo "===== 13 ====="
     # The remaining steps don't work any more as the steps required have changed due to one-proposal
     #dfx sns propose
     # SNS canister IDs should be saved

--- a/extensions/sns/extension.json
+++ b/extensions/sns/extension.json
@@ -15,6 +15,40 @@
   ],
   "description": null,
   "subcommands": {
+    "add-sns-wasm-for-tests": {
+      "about": "Add a wasms for one of the SNS canisters, skipping the NNS proposal, for tests",
+      "args": {
+        "canister_type": {
+          "about": "The type of the canister that the wasm is for. Must be one of \"archive\", \"root\", \"governance\", \"ledger\", \"swap\", \"index\"",
+          "long": null,
+          "short": null,
+          "multiple": false,
+          "values": 1
+        },
+        "network": {
+          "about": "The network to deploy to. This can be \"local\", \"ic\", or the URL of an IC network",
+          "long": "network",
+          "short": null,
+          "multiple": false,
+          "values": 1
+        },
+        "override_sns_wasm_canister_id_for_tests": {
+          "about": "The canister ID of SNS-WASM to use instead of the default",
+          "long": "override-sns-wasm-canister-id-for-tests",
+          "short": null,
+          "multiple": false,
+          "values": 1
+        },
+        "wasm_file": {
+          "about": "The wasm faile to be added to a test instance of SNS-WASM",
+          "long": "wasm-file",
+          "short": null,
+          "multiple": false,
+          "values": 1
+        }
+      },
+      "subcommands": null
+    },
     "deploy-testflight": {
       "about": "Deploy an sns directly to a subnet, skipping the sns-wasms canister. The SNS canisters remain controlled by the developer after deployment. For use in tests only",
       "args": {
@@ -121,6 +155,19 @@
           "subcommands": null
         }
       }
+    },
+    "list": {
+      "about": "List SNSes",
+      "args": {
+        "json": {
+          "about": "Output the SNS information as JSON (instead of a human-friendly table)",
+          "long": "json",
+          "short": null,
+          "multiple": false,
+          "values": 0
+        }
+      },
+      "subcommands": null
     },
     "neuron-id-to-candid-subaccount": {
       "about": "Converts a Neuron ID to a candid subaccount blob suitable for use in the `manage_neuron` method on SNS Governance",

--- a/extensions/sns/src/main.rs
+++ b/extensions/sns/src/main.rs
@@ -80,6 +80,12 @@ enum SubCommand {
 async fn main() -> anyhow::Result<()> {
     let opts = SnsOpts::parse();
 
+    // Most of the branches in here convert SubCommand to SnsLibSubCommand.
+    // The purpose of this is to allow us to match on SnsLibSubCommand. This causes
+    // us to have a compiler error if we add a new subcommand to SnsLibSubCommand
+    // and don't have some corresponding handling here.
+    // TODO(NNS1-3184): Once we remove `Import` and `Download`, this extra step will no longer be
+    // needed as we can directly parse the monorepo's command type and subcommands.
     let subcommand: SnsLibSubCommand = match opts.subcmd {
         SubCommand::DeployTestflight(args) => SnsLibSubCommand::DeployTestflight(args),
         SubCommand::InitConfigFile(args) => SnsLibSubCommand::InitConfigFile(args),

--- a/extensions/sns/src/utils.rs
+++ b/extensions/sns/src/utils.rs
@@ -1,0 +1,15 @@
+use anyhow::{anyhow, Result};
+use ic_agent::agent::Agent;
+
+fn get_agent(ic_url: &str) -> Result<Agent> {
+    Agent::builder()
+        .with_url(ic_url)
+        .with_verify_query_signatures(false)
+        .build()
+        .map_err(|e| anyhow!(e))
+}
+
+pub fn get_mainnet_agent() -> Result<Agent> {
+    let ic_url = "https://ic0.app/";
+    get_agent(ic_url)
+}

--- a/extensions/sns/src/utils.rs
+++ b/extensions/sns/src/utils.rs
@@ -1,14 +1,17 @@
+//! Utility functions for the SNS extension.
+
 use anyhow::{anyhow, Result};
 use ic_agent::agent::Agent;
 
+/// Gets the agent corresponding to the given IC URL.
 fn get_agent(ic_url: &str) -> Result<Agent> {
     Agent::builder()
         .with_url(ic_url)
-        .with_verify_query_signatures(false)
         .build()
         .map_err(|e| anyhow!(e))
 }
 
+/// Gets the agent for IC mainnet.
 pub fn get_mainnet_agent() -> Result<Agent> {
     let ic_url = "https://ic0.app/";
     get_agent(ic_url)


### PR DESCRIPTION
This brings it in sync with the monorepo's sns cli. 

`add-sns-wasm-for-tests` is hidden as it's relatively "developer only" and I don't have a good idea of when it's needed, other than that I know snsdemo uses it.

The commands were implemented in the monorepo, and are just called from here.