### PR TITLE
fix: use cargo-dist install script

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -39,9 +39,8 @@ jobs:
         if: contains(matrix.os, 'macos-12') == false
       - name: Install sponge and timeout 
         run: brew install coreutils sponge
-      - uses: cargo-bins/cargo-binstall@main
       - name: Install cargo-dist
-        run: cargo binstall cargo-dist@0.10.0 -y
+        run: curl --proto '=https' --tlsv1.2 -LsSf https://axodotdev.artifacts.axodotdev.host/cargo-dist/v0.10.0/cargo-dist-installer.sh | sh
       - name: Install IC SDK (dfx)
         uses: dfinity/setup-dfx@main
         with:


### PR DESCRIPTION
Use the command specified at https://github.com/axodotdev/cargo-dist/releases/tag/v0.10.0 to install cargo-dist.

Intended to reduce CI failures seen when using cargo-binstall