### PR TITLE
refactor: avoid using block_on when we already have an async runtime

### DIFF
--- a/extensions/sns/e2e/tests/sns.bash
+++ b/extensions/sns/e2e/tests/sns.bash
@@ -69,6 +69,8 @@ SNS_CONFIG_FILE_NAME="sns_init.yaml"
     dfx nns install
     echo "===== 7 ====="
     dfx nns import
+    echo "===== 8 ====="
+    dfx sns import
     echo "===== 9 ====="
     ls candid
     echo "===== 10 ====="

--- a/extensions/sns/src/commands/download.rs
+++ b/extensions/sns/src/commands/download.rs
@@ -18,13 +18,12 @@ pub struct SnsDownloadOpts {
 }
 
 /// Executes the command line `dfx sns import`.
-pub fn exec(opts: SnsDownloadOpts, dfx_cache_path: &Path) -> anyhow::Result<()> {
-    let runtime = Runtime::new().expect("Unable to create a runtime");
+pub async fn exec(opts: SnsDownloadOpts, dfx_cache_path: &Path) -> anyhow::Result<()> {
     let ic_commit = if let Some(ic_commit) = opts.ic_commit {
         ic_commit
     } else {
         replica_rev(dfx_cache_path)?
     };
-    runtime.block_on(download_sns_wasms(&ic_commit, &opts.wasms_dir))?;
+    download_sns_wasms(&ic_commit, &opts.wasms_dir).await?;
     Ok(())
 }

--- a/extensions/sns/src/main.rs
+++ b/extensions/sns/src/main.rs
@@ -103,7 +103,7 @@ async fn main() -> anyhow::Result<()> {
                     "Missing path to dfx cache. Pass it as CLI argument: `--dfx-cache-path=PATH`",
                 )
             })?;
-            return commands::import::exec(v, dfx_cache_path);
+            return commands::import::exec(v, dfx_cache_path).await;
         }
         SubCommand::Download(v) => {
             let dfx_cache_path = &opts.dfx_cache_path.ok_or_else(|| {
@@ -111,7 +111,7 @@ async fn main() -> anyhow::Result<()> {
                     "Missing path to dfx cache. Pass it as CLI argument: `--dfx-cache-path=PATH`",
                 )
             })?;
-            return commands::download::exec(v, dfx_cache_path);
+            return commands::download::exec(v, dfx_cache_path).await;
         }
     };
 


### PR DESCRIPTION
This was causing an issue with `sns import` and `sns download` as creating a runtime within a runtime is unsupported. It's nice when you can remove code to fix a bug :) 