### PR TITLE
Update replica rev / IC monorepo version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -208,45 +208,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
-name = "asn1-rs"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5493c3bedbacf7fd7382c6346bbd66687d12bbaad3a89a2d2c303ee6cf20b048"
-dependencies = [
- "asn1-rs-derive",
- "asn1-rs-impl",
- "displaydoc",
- "nom",
- "num-traits",
- "rusticata-macros",
- "thiserror",
- "time",
-]
-
-[[package]]
-name = "asn1-rs-derive"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.77",
- "synstructure",
-]
-
-[[package]]
-name = "asn1-rs-impl"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.77",
-]
-
-[[package]]
 name = "async-io"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -655,18 +616,6 @@ name = "bytes"
 version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8318a53db07bb3f8dca91a600466bdb3f2eaadeedfdbcf02e1accbad9271ba50"
-
-[[package]]
-name = "cached"
-version = "0.49.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e8e463fceca5674287f32d252fb1d94083758b8709c160efae66d263e5f4eba"
-dependencies = [
- "hashbrown 0.14.5",
- "instant",
- "once_cell",
- "thiserror",
-]
 
 [[package]]
 name = "cached"
@@ -1112,27 +1061,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "csv"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac574ff4d437a7b5ad237ef331c17ccca63c46479e5b5453eb8e10bb99a759fe"
-dependencies = [
- "csv-core",
- "itoa",
- "ryu",
- "serde",
-]
-
-[[package]]
-name = "csv-core"
-version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5efa2b3d7902f4b634a20cae3c9c4e6209dc4779feb6863329607560143efa70"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "ctr"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1195,7 +1123,7 @@ dependencies = [
 [[package]]
 name = "cycles-minting-canister"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
+source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
 dependencies = [
  "async-trait",
  "base64 0.13.1",
@@ -1338,20 +1266,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "der-parser"
-version = "9.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cd0a5c643689626bec213c4d8bd4d96acc8ffdb4ad4bb6bc16abf27d5f4b553"
-dependencies = [
- "asn1-rs",
- "displaydoc",
- "nom",
- "num-bigint 0.4.6",
- "num-traits",
- "rusticata-macros",
-]
-
-[[package]]
 name = "deranged"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1388,7 +1302,7 @@ dependencies = [
 [[package]]
 name = "dfn_candid"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
+source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
 dependencies = [
  "candid",
  "dfn_core",
@@ -1400,7 +1314,7 @@ dependencies = [
 [[package]]
 name = "dfn_core"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
+source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
 dependencies = [
  "ic-base-types",
  "on_wire",
@@ -1409,7 +1323,7 @@ dependencies = [
 [[package]]
 name = "dfn_http"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
+source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
 dependencies = [
  "candid",
  "dfn_candid",
@@ -1421,7 +1335,7 @@ dependencies = [
 [[package]]
 name = "dfn_http_metrics"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
+source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
 dependencies = [
  "dfn_candid",
  "dfn_core",
@@ -1434,7 +1348,7 @@ dependencies = [
 [[package]]
 name = "dfn_protobuf"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
+source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
 dependencies = [
  "on_wire",
  "prost",
@@ -1580,17 +1494,6 @@ dependencies = [
  "libc",
  "redox_users",
  "winapi",
-]
-
-[[package]]
-name = "displaydoc"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.77",
 ]
 
 [[package]]
@@ -1834,19 +1737,6 @@ name = "fastrand"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
-
-[[package]]
-name = "fe-derive"
-version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
-dependencies = [
- "hex",
- "num-bigint-dig",
- "num-traits",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
 
 [[package]]
 name = "ff"
@@ -2277,12 +2167,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hex-literal"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
-
-[[package]]
 name = "hkdf"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2572,7 +2456,7 @@ checksum = "3fd3fdf5e5c4f4a9fe5ca612f0febd22dcb161d2f2b75b0142326732be5e4978"
 dependencies = [
  "async-lock 3.4.0",
  "backoff",
- "cached 0.52.0",
+ "cached",
  "candid",
  "ed25519-consensus",
  "futures-util",
@@ -2618,7 +2502,7 @@ source = "git+https://github.com/dfinity/agent-rs?rev=6e11a350112f9b907c4d590d82
 dependencies = [
  "async-lock 3.4.0",
  "backoff",
- "cached 0.52.0",
+ "cached",
  "candid",
  "ed25519-consensus",
  "futures-util",
@@ -2654,17 +2538,20 @@ dependencies = [
 [[package]]
 name = "ic-base-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
+source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
 dependencies = [
  "byte-unit",
  "bytes",
  "candid",
  "comparable",
+ "hex",
  "ic-crypto-sha2",
  "ic-protobuf",
  "phantom_newtype",
  "prost",
  "serde",
+ "strum",
+ "strum_macros",
 ]
 
 [[package]]
@@ -2681,7 +2568,7 @@ dependencies = [
 [[package]]
 name = "ic-btc-replica-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
+source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
 dependencies = [
  "candid",
  "ic-btc-interface",
@@ -2694,7 +2581,7 @@ dependencies = [
 [[package]]
 name = "ic-canister-client-sender"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
+source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
 dependencies = [
  "ic-base-types",
  "ic-crypto-ed25519",
@@ -2707,7 +2594,7 @@ dependencies = [
 [[package]]
 name = "ic-canister-log"
 version = "0.2.0"
-source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
+source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
 dependencies = [
  "serde",
 ]
@@ -2715,7 +2602,7 @@ dependencies = [
 [[package]]
 name = "ic-canister-profiler"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
+source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
 dependencies = [
  "ic-metrics-encoder",
  "ic0 0.18.11",
@@ -2724,7 +2611,7 @@ dependencies = [
 [[package]]
 name = "ic-canisters-http-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
+source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
 dependencies = [
  "candid",
  "dfn_candid",
@@ -2813,7 +2700,7 @@ dependencies = [
 [[package]]
 name = "ic-config"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
+source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
 dependencies = [
  "ic-base-types",
  "ic-protobuf",
@@ -2826,14 +2713,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "ic-constants"
-version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
-
-[[package]]
 name = "ic-crypto-ed25519"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
+source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
 dependencies = [
  "curve25519-dalek",
  "ed25519-dalek",
@@ -2847,169 +2729,23 @@ dependencies = [
 [[package]]
 name = "ic-crypto-getrandom-for-wasm"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
+source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
 dependencies = [
  "getrandom",
 ]
 
 [[package]]
-name = "ic-crypto-internal-basic-sig-der-utils"
-version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
-dependencies = [
- "hex",
- "ic-types",
- "simple_asn1",
-]
-
-[[package]]
-name = "ic-crypto-internal-basic-sig-ed25519"
-version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
-dependencies = [
- "base64 0.13.1",
- "curve25519-dalek",
- "hex",
- "ic-crypto-ed25519",
- "ic-crypto-internal-basic-sig-der-utils",
- "ic-crypto-internal-seed",
- "ic-crypto-internal-types",
- "ic-crypto-secrets-containers",
- "ic-protobuf",
- "ic-types",
- "rand",
- "rand_chacha",
- "serde",
- "simple_asn1",
- "zeroize",
-]
-
-[[package]]
-name = "ic-crypto-internal-bls12-381-type"
-version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
-dependencies = [
- "hex",
- "ic_bls12_381",
- "itertools 0.12.1",
- "lazy_static",
- "pairing",
- "paste",
- "rand",
- "rand_chacha",
- "sha2 0.10.8",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "ic-crypto-internal-hmac"
-version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
-dependencies = [
- "ic-crypto-internal-sha2",
-]
-
-[[package]]
-name = "ic-crypto-internal-multi-sig-bls12381"
-version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
-dependencies = [
- "base64 0.13.1",
- "hex",
- "ic-crypto-internal-bls12-381-type",
- "ic-crypto-internal-types",
- "ic-crypto-secrets-containers",
- "ic-crypto-sha2",
- "ic-protobuf",
- "ic-types",
- "rand",
- "rand_chacha",
- "serde",
- "zeroize",
-]
-
-[[package]]
-name = "ic-crypto-internal-seed"
-version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
-dependencies = [
- "hex",
- "ic-crypto-sha2",
- "rand",
- "rand_chacha",
- "serde",
- "zeroize",
-]
-
-[[package]]
 name = "ic-crypto-internal-sha2"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
+source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
 dependencies = [
  "sha2 0.10.8",
-]
-
-[[package]]
-name = "ic-crypto-internal-threshold-sig-bls12381"
-version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
-dependencies = [
- "base64 0.13.1",
- "cached 0.49.3",
- "hex",
- "ic-crypto-internal-bls12-381-type",
- "ic-crypto-internal-seed",
- "ic-crypto-internal-types",
- "ic-crypto-secrets-containers",
- "ic-crypto-sha2",
- "ic-types",
- "lazy_static",
- "parking_lot",
- "rand",
- "rand_chacha",
- "serde",
- "serde_bytes",
- "serde_cbor",
- "strum_macros",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "ic-crypto-internal-threshold-sig-ecdsa"
-version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
-dependencies = [
- "curve25519-dalek",
- "fe-derive",
- "group 0.13.0",
- "hex",
- "hex-literal",
- "ic-crypto-internal-hmac",
- "ic-crypto-internal-seed",
- "ic-crypto-internal-types",
- "ic-crypto-secrets-containers",
- "ic-crypto-sha2",
- "ic-types",
- "k256 0.13.3",
- "lazy_static",
- "p256",
- "paste",
- "rand",
- "serde",
- "serde_bytes",
- "serde_cbor",
- "strum",
- "strum_macros",
- "subtle",
- "zeroize",
 ]
 
 [[package]]
 name = "ic-crypto-internal-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
+source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
 dependencies = [
  "arrayvec 0.7.6",
  "hex",
@@ -3024,27 +2760,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "ic-crypto-node-key-validation"
-version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
-dependencies = [
- "hex",
- "ic-base-types",
- "ic-crypto-internal-basic-sig-ed25519",
- "ic-crypto-internal-multi-sig-bls12381",
- "ic-crypto-internal-threshold-sig-bls12381",
- "ic-crypto-internal-threshold-sig-ecdsa",
- "ic-crypto-internal-types",
- "ic-crypto-tls-cert-validation",
- "ic-protobuf",
- "ic-types",
- "serde",
-]
-
-[[package]]
 name = "ic-crypto-secp256k1"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
+source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
 dependencies = [
  "hmac 0.12.1",
  "k256 0.13.3",
@@ -3058,39 +2776,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "ic-crypto-secrets-containers"
-version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
-dependencies = [
- "serde",
- "zeroize",
-]
-
-[[package]]
 name = "ic-crypto-sha2"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
+source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
 dependencies = [
  "ic-crypto-internal-sha2",
 ]
 
 [[package]]
-name = "ic-crypto-tls-cert-validation"
-version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
-dependencies = [
- "hex",
- "ic-crypto-internal-basic-sig-ed25519",
- "ic-protobuf",
- "ic-types",
- "serde",
- "x509-parser",
-]
-
-[[package]]
 name = "ic-crypto-tree-hash"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
+source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
 dependencies = [
  "ic-crypto-internal-types",
  "ic-crypto-sha2",
@@ -3101,29 +2797,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "ic-crypto-utils-basic-sig"
-version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
-dependencies = [
- "ic-base-types",
- "ic-crypto-ed25519",
- "ic-protobuf",
-]
-
-[[package]]
-name = "ic-crypto-utils-ni-dkg"
-version = "0.8.0"
-source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
-dependencies = [
- "ic-crypto-internal-types",
- "ic-protobuf",
- "ic-types",
-]
-
-[[package]]
 name = "ic-error-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
+source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
 dependencies = [
  "ic-protobuf",
  "ic-utils 0.9.0",
@@ -3135,7 +2811,7 @@ dependencies = [
 [[package]]
 name = "ic-http-utils"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
+source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
 dependencies = [
  "flate2",
  "hex",
@@ -3152,7 +2828,7 @@ dependencies = [
 [[package]]
 name = "ic-icp-index"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
+source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
 dependencies = [
  "candid",
  "ciborium",
@@ -3180,7 +2856,7 @@ dependencies = [
 [[package]]
 name = "ic-icrc1"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
+source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
 dependencies = [
  "candid",
  "ciborium",
@@ -3203,7 +2879,7 @@ dependencies = [
 [[package]]
 name = "ic-icrc1-index-ng"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
+source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
 dependencies = [
  "candid",
  "ciborium",
@@ -3231,7 +2907,7 @@ dependencies = [
 [[package]]
 name = "ic-icrc1-ledger"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
+source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
 dependencies = [
  "async-trait",
  "candid",
@@ -3249,6 +2925,7 @@ dependencies = [
  "ic-ledger-core",
  "ic-ledger-hash-of",
  "ic-metrics-encoder",
+ "ic-stable-structures",
  "icrc-ledger-client",
  "icrc-ledger-types",
  "num-traits",
@@ -3259,7 +2936,7 @@ dependencies = [
 [[package]]
 name = "ic-icrc1-tokens-u64"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
+source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
 dependencies = [
  "candid",
  "ic-ledger-core",
@@ -3284,15 +2961,15 @@ dependencies = [
 [[package]]
 name = "ic-ledger-canister-core"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
+source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
 dependencies = [
  "async-trait",
  "candid",
  "ic-base-types",
  "ic-canister-log",
- "ic-constants",
  "ic-ledger-core",
  "ic-ledger-hash-of",
+ "ic-limits",
  "ic-management-canister-types",
  "ic-utils 0.9.0",
  "num-traits",
@@ -3302,7 +2979,7 @@ dependencies = [
 [[package]]
 name = "ic-ledger-core"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
+source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
 dependencies = [
  "candid",
  "ic-ledger-hash-of",
@@ -3314,7 +2991,7 @@ dependencies = [
 [[package]]
 name = "ic-ledger-hash-of"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
+source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
 dependencies = [
  "candid",
  "hex",
@@ -3322,9 +2999,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "ic-limits"
+version = "0.9.0"
+source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
+
+[[package]]
 name = "ic-logger"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
+source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
 dependencies = [
  "chrono",
  "ic-config",
@@ -3341,7 +3023,7 @@ dependencies = [
 [[package]]
 name = "ic-management-canister-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
+source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
 dependencies = [
  "candid",
  "ic-base-types",
@@ -3367,7 +3049,7 @@ checksum = "8b5c7628eac357aecda461130f8074468be5aa4d258a002032d82d817f79f1f8"
 [[package]]
 name = "ic-nervous-system-agent"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
+source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
 dependencies = [
  "anyhow",
  "candid",
@@ -3379,13 +3061,31 @@ dependencies = [
  "ic-sns-wasm",
  "serde",
  "tempfile",
+ "thiserror",
  "tokio",
+]
+
+[[package]]
+name = "ic-nervous-system-canisters"
+version = "0.9.0"
+source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
+dependencies = [
+ "async-trait",
+ "candid",
+ "dfn_core",
+ "ic-base-types",
+ "ic-ledger-core",
+ "ic-nervous-system-common",
+ "ic-nervous-system-runtime",
+ "ic-nns-constants",
+ "icp-ledger",
+ "icrc-ledger-types",
 ]
 
 [[package]]
 name = "ic-nervous-system-clients"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
+source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
 dependencies = [
  "async-trait",
  "candid",
@@ -3408,12 +3108,12 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-collections-union-multi-map"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
+source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
 
 [[package]]
 name = "ic-nervous-system-common"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
+source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
 dependencies = [
  "async-trait",
  "base64 0.13.1",
@@ -3422,7 +3122,6 @@ dependencies = [
  "by_address",
  "bytes",
  "dfn_core",
- "dfn_protobuf",
  "ic-base-types",
  "ic-canister-log",
  "ic-canisters-http-types",
@@ -3449,12 +3148,12 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-common-build-metadata"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
+source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
 
 [[package]]
 name = "ic-nervous-system-common-test-keys"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
+source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
 dependencies = [
  "ic-base-types",
  "ic-canister-client-sender",
@@ -3465,9 +3164,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "ic-nervous-system-common-validation"
+version = "0.9.0"
+source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
+
+[[package]]
 name = "ic-nervous-system-governance"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
+source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
 dependencies = [
  "ic-base-types",
  "ic-stable-structures",
@@ -3479,7 +3183,7 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-humanize"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
+source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
 dependencies = [
  "humantime",
  "ic-nervous-system-proto",
@@ -3491,12 +3195,12 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-lock"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
+source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
 
 [[package]]
 name = "ic-nervous-system-proto"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
+source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
 dependencies = [
  "candid",
  "comparable",
@@ -3509,7 +3213,7 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-proxied-canister-calls-tracker"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
+source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
 dependencies = [
  "ic-base-types",
 ]
@@ -3517,7 +3221,7 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-root"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
+source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
 dependencies = [
  "candid",
  "dfn_core",
@@ -3533,7 +3237,7 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-runtime"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
+source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
 dependencies = [
  "async-trait",
  "candid",
@@ -3546,17 +3250,12 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-string"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
-
-[[package]]
-name = "ic-nervous-system-temporary"
-version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
+source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
 
 [[package]]
 name = "ic-neurons-fund"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
+source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
 dependencies = [
  "ic-nervous-system-common",
  "lazy_static",
@@ -3569,7 +3268,7 @@ dependencies = [
 [[package]]
 name = "ic-nns-common"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
+source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
 dependencies = [
  "candid",
  "comparable",
@@ -3595,86 +3294,16 @@ dependencies = [
 [[package]]
 name = "ic-nns-constants"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
+source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
 dependencies = [
  "ic-base-types",
  "maplit",
-]
-
-[[package]]
-name = "ic-nns-governance"
-version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
-dependencies = [
- "async-trait",
- "build-info",
- "build-info-build",
- "bytes",
- "candid",
- "comparable",
- "csv",
- "cycles-minting-canister",
- "dfn_candid",
- "dfn_core",
- "dfn_http_metrics",
- "dfn_protobuf",
- "dyn-clone",
- "ic-base-types",
- "ic-crypto-getrandom-for-wasm",
- "ic-crypto-sha2",
- "ic-ledger-core",
- "ic-management-canister-types",
- "ic-metrics-encoder",
- "ic-nervous-system-clients",
- "ic-nervous-system-common",
- "ic-nervous-system-common-build-metadata",
- "ic-nervous-system-common-test-keys",
- "ic-nervous-system-governance",
- "ic-nervous-system-proto",
- "ic-nervous-system-root",
- "ic-nervous-system-runtime",
- "ic-nervous-system-temporary",
- "ic-neurons-fund",
- "ic-nns-common",
- "ic-nns-constants",
- "ic-nns-governance-api",
- "ic-nns-governance-init",
- "ic-nns-gtc-accounts",
- "ic-nns-handler-root-interface",
- "ic-protobuf",
- "ic-sns-init",
- "ic-sns-root",
- "ic-sns-swap",
- "ic-sns-wasm",
- "ic-stable-structures",
- "ic-types",
- "ic-utils 0.9.0",
- "icp-ledger",
- "itertools 0.12.1",
- "lazy_static",
- "maplit",
- "mockall",
- "num-traits",
- "on_wire",
- "pretty_assertions",
- "prometheus-parse",
- "prost",
- "rand",
- "rand_chacha",
- "registry-canister",
- "rust_decimal",
- "rust_decimal_macros",
- "serde",
- "serde_bytes",
- "serde_json",
- "strum",
- "strum_macros",
 ]
 
 [[package]]
 name = "ic-nns-governance-api"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
+source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
 dependencies = [
  "bytes",
  "candid",
@@ -3682,6 +3311,7 @@ dependencies = [
  "ic-base-types",
  "ic-crypto-sha2",
  "ic-nervous-system-clients",
+ "ic-nervous-system-common-validation",
  "ic-nervous-system-proto",
  "ic-nns-common",
  "ic-protobuf",
@@ -3699,31 +3329,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "ic-nns-governance-init"
-version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
-dependencies = [
- "csv",
- "ic-base-types",
- "ic-nervous-system-common",
- "ic-nervous-system-common-build-metadata",
- "ic-nervous-system-common-test-keys",
- "ic-nns-common",
- "ic-nns-governance-api",
- "icp-ledger",
- "rand",
- "rand_chacha",
-]
-
-[[package]]
-name = "ic-nns-gtc-accounts"
-version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
-
-[[package]]
 name = "ic-nns-handler-root-interface"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
+source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
 dependencies = [
  "async-trait",
  "candid",
@@ -3738,7 +3346,7 @@ dependencies = [
 [[package]]
 name = "ic-protobuf"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
+source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
 dependencies = [
  "bincode",
  "candid",
@@ -3750,20 +3358,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "ic-registry-canister-api"
-version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
-dependencies = [
- "candid",
- "ic-base-types",
- "serde",
- "thiserror",
-]
-
-[[package]]
 name = "ic-registry-keys"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
+source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
 dependencies = [
  "candid",
  "ic-base-types",
@@ -3773,40 +3370,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "ic-registry-node-provider-rewards"
-version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
-dependencies = [
- "ic-base-types",
- "ic-protobuf",
-]
-
-[[package]]
-name = "ic-registry-routing-table"
-version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
-dependencies = [
- "candid",
- "ic-base-types",
- "ic-protobuf",
- "serde",
-]
-
-[[package]]
-name = "ic-registry-subnet-features"
-version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
-dependencies = [
- "candid",
- "ic-management-canister-types",
- "ic-protobuf",
- "serde",
-]
-
-[[package]]
 name = "ic-registry-subnet-type"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
+source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
 dependencies = [
  "candid",
  "ic-protobuf",
@@ -3818,7 +3384,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-transport"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
+source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
 dependencies = [
  "candid",
  "ic-base-types",
@@ -3830,7 +3396,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-cli"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
+source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
 dependencies = [
  "anyhow",
  "base64 0.13.1",
@@ -3848,7 +3414,7 @@ dependencies = [
  "ic-nervous-system-proto",
  "ic-nns-common",
  "ic-nns-constants",
- "ic-nns-governance",
+ "ic-nns-governance-api",
  "ic-sns-governance",
  "ic-sns-init",
  "ic-sns-root",
@@ -3867,7 +3433,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-governance"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
+source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
 dependencies = [
  "async-trait",
  "base64 0.13.1",
@@ -3888,10 +3454,12 @@ dependencies = [
  "ic-ledger-core",
  "ic-management-canister-types",
  "ic-metrics-encoder",
+ "ic-nervous-system-canisters",
  "ic-nervous-system-clients",
  "ic-nervous-system-collections-union-multi-map",
  "ic-nervous-system-common",
  "ic-nervous-system-common-build-metadata",
+ "ic-nervous-system-common-validation",
  "ic-nervous-system-governance",
  "ic-nervous-system-lock",
  "ic-nervous-system-proto",
@@ -3924,7 +3492,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-governance-proposal-criticality"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
+source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
 dependencies = [
  "ic-nervous-system-proto",
 ]
@@ -3932,7 +3500,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-governance-proposals-amount-total-limit"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
+source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
 dependencies = [
  "ic-sns-governance-token-valuation",
  "num-traits",
@@ -3943,7 +3511,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-governance-token-valuation"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
+source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
 dependencies = [
  "async-trait",
  "candid",
@@ -3964,7 +3532,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-init"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
+source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
 dependencies = [
  "base64 0.13.1",
  "candid",
@@ -3976,6 +3544,7 @@ dependencies = [
  "ic-nervous-system-common",
  "ic-nervous-system-proto",
  "ic-nns-constants",
+ "ic-nns-governance-api",
  "ic-sns-governance",
  "ic-sns-root",
  "ic-sns-swap",
@@ -3991,7 +3560,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-root"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
+source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
 dependencies = [
  "async-trait",
  "build-info",
@@ -4004,6 +3573,7 @@ dependencies = [
  "ic-canisters-http-types",
  "ic-cdk",
  "ic-cdk-macros 0.9.0",
+ "ic-cdk-timers",
  "ic-management-canister-types",
  "ic-metrics-encoder",
  "ic-nervous-system-clients",
@@ -4011,6 +3581,7 @@ dependencies = [
  "ic-nervous-system-common-build-metadata",
  "ic-nervous-system-root",
  "ic-nervous-system-runtime",
+ "ic-nns-constants",
  "ic-sns-swap",
  "icrc-ledger-types",
  "prost",
@@ -4020,7 +3591,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-swap"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
+source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
 dependencies = [
  "async-trait",
  "build-info",
@@ -4035,6 +3606,7 @@ dependencies = [
  "ic-canisters-http-types",
  "ic-ledger-core",
  "ic-metrics-encoder",
+ "ic-nervous-system-canisters",
  "ic-nervous-system-clients",
  "ic-nervous-system-common",
  "ic-nervous-system-proto",
@@ -4058,7 +3630,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-swap-proto-library"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
+source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
 dependencies = [
  "candid",
  "comparable",
@@ -4073,7 +3645,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-wasm"
 version = "1.0.0"
-source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
+source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
 dependencies = [
  "async-trait",
  "candid",
@@ -4119,7 +3691,7 @@ dependencies = [
 [[package]]
 name = "ic-sys"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
+source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
 dependencies = [
  "cvt",
  "hex",
@@ -4171,7 +3743,7 @@ dependencies = [
 [[package]]
 name = "ic-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
+source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
 dependencies = [
  "base64 0.13.1",
  "bincode",
@@ -4180,11 +3752,11 @@ dependencies = [
  "hex",
  "ic-base-types",
  "ic-btc-replica-types",
- "ic-constants",
  "ic-crypto-internal-types",
  "ic-crypto-sha2",
  "ic-crypto-tree-hash",
  "ic-error-types",
+ "ic-limits",
  "ic-management-canister-types",
  "ic-protobuf",
  "ic-utils 0.9.0",
@@ -4208,7 +3780,7 @@ dependencies = [
 [[package]]
 name = "ic-utils"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
+source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
 dependencies = [
  "hex",
  "scoped_threadpool",
@@ -4240,7 +3812,7 @@ dependencies = [
 [[package]]
 name = "ic-validate-eq"
 version = "0.0.0"
-source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
+source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
 dependencies = [
  "ic-validate-eq-derive",
 ]
@@ -4248,7 +3820,7 @@ dependencies = [
 [[package]]
 name = "ic-validate-eq-derive"
 version = "0.0.0"
-source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
+source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
 dependencies = [
  "darling 0.20.10",
  "proc-macro2",
@@ -4321,7 +3893,6 @@ dependencies = [
  "pairing",
  "rand_core",
  "subtle",
- "zeroize",
 ]
 
 [[package]]
@@ -4340,7 +3911,7 @@ dependencies = [
 [[package]]
 name = "icp-ledger"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
+source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
 dependencies = [
  "candid",
  "comparable",
@@ -4370,7 +3941,7 @@ dependencies = [
 [[package]]
 name = "icrc-ledger-client"
 version = "0.1.2"
-source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
+source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
 dependencies = [
  "async-trait",
  "candid",
@@ -4381,7 +3952,7 @@ dependencies = [
 [[package]]
 name = "icrc-ledger-types"
 version = "0.1.6"
-source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
+source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
 dependencies = [
  "base32",
  "candid",
@@ -4395,124 +3966,6 @@ dependencies = [
  "sha2 0.10.8",
  "strum",
  "time",
-]
-
-[[package]]
-name = "icu_collections"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526"
-dependencies = [
- "displaydoc",
- "yoke",
- "zerofrom",
- "zerovec",
-]
-
-[[package]]
-name = "icu_locid"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637"
-dependencies = [
- "displaydoc",
- "litemap",
- "tinystr",
- "writeable",
- "zerovec",
-]
-
-[[package]]
-name = "icu_locid_transform"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01d11ac35de8e40fdeda00d9e1e9d92525f3f9d887cdd7aa81d727596788b54e"
-dependencies = [
- "displaydoc",
- "icu_locid",
- "icu_locid_transform_data",
- "icu_provider",
- "tinystr",
- "zerovec",
-]
-
-[[package]]
-name = "icu_locid_transform_data"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdc8ff3388f852bede6b579ad4e978ab004f139284d7b28715f773507b946f6e"
-
-[[package]]
-name = "icu_normalizer"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19ce3e0da2ec68599d193c93d088142efd7f9c5d6fc9b803774855747dc6a84f"
-dependencies = [
- "displaydoc",
- "icu_collections",
- "icu_normalizer_data",
- "icu_properties",
- "icu_provider",
- "smallvec",
- "utf16_iter",
- "utf8_iter",
- "write16",
- "zerovec",
-]
-
-[[package]]
-name = "icu_normalizer_data"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8cafbf7aa791e9b22bec55a167906f9e1215fd475cd22adfcf660e03e989516"
-
-[[package]]
-name = "icu_properties"
-version = "1.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93d6020766cfc6302c15dbbc9c8778c37e62c14427cb7f6e601d849e092aeef5"
-dependencies = [
- "displaydoc",
- "icu_collections",
- "icu_locid_transform",
- "icu_properties_data",
- "icu_provider",
- "tinystr",
- "zerovec",
-]
-
-[[package]]
-name = "icu_properties_data"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67a8effbc3dd3e4ba1afa8ad918d5684b8868b3b26500753effea8d2eed19569"
-
-[[package]]
-name = "icu_provider"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ed421c8a8ef78d3e2dbc98a973be2f3770cb42b606e3ab18d6237c4dfde68d9"
-dependencies = [
- "displaydoc",
- "icu_locid",
- "icu_provider_macros",
- "stable_deref_trait",
- "tinystr",
- "writeable",
- "yoke",
- "zerofrom",
- "zerovec",
-]
-
-[[package]]
-name = "icu_provider_macros"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.77",
 ]
 
 [[package]]
@@ -4535,18 +3988,6 @@ checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
 dependencies = [
  "unicode-bidi",
  "unicode-normalization",
-]
-
-[[package]]
-name = "idna"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd69211b9b519e98303c015e21a007e293db403b6c85b9b124e133d25e242cdd"
-dependencies = [
- "icu_normalizer",
- "icu_properties",
- "smallvec",
- "utf8_iter",
 ]
 
 [[package]]
@@ -4749,9 +4190,6 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-dependencies = [
- "spin 0.9.8",
-]
 
 [[package]]
 name = "leb128"
@@ -4839,12 +4277,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
-name = "litemap"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "643cb0b8d4fcc284004d5fd0d67ccf61dfffadb7f75e1e71bc420f4688a3a704"
-
-[[package]]
 name = "lock_api"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4919,12 +4351,6 @@ dependencies = [
  "mime",
  "unicase",
 ]
-
-[[package]]
-name = "minimal-lexical"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
@@ -5062,16 +4488,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nom"
-version = "7.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
-dependencies = [
- "memchr",
- "minimal-lexical",
-]
-
-[[package]]
 name = "num"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5105,23 +4521,6 @@ dependencies = [
  "num-integer",
  "num-traits",
  "serde",
-]
-
-[[package]]
-name = "num-bigint-dig"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc84195820f291c7697304f3cbdadd1cb7199c0efc917ff5eafd71225c136151"
-dependencies = [
- "byteorder",
- "lazy_static",
- "libm",
- "num-integer",
- "num-iter",
- "num-traits",
- "rand",
- "serde",
- "smallvec",
 ]
 
 [[package]]
@@ -5190,18 +4589,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "oid-registry"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8d8034d9489cdaf79228eb9f6a3b8d7bb32ba00d6645ebd48eef4077ceb5bd9"
-dependencies = [
- "asn1-rs",
-]
-
-[[package]]
 name = "on_wire"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
+source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
 
 [[package]]
 name = "once_cell"
@@ -5452,9 +4842,10 @@ dependencies = [
 [[package]]
 name = "phantom_newtype"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
+source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
 dependencies = [
  "candid",
+ "num-traits",
  "serde",
  "slog",
 ]
@@ -5714,18 +5105,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "prometheus-parse"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "811031bea65e5a401fb2e1f37d802cca6601e204ac463809a3189352d13b78a5"
-dependencies = [
- "chrono",
- "itertools 0.12.1",
- "once_cell",
- "regex",
-]
-
-[[package]]
 name = "prost"
 version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5954,50 +5333,6 @@ name = "regex-syntax"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
-
-[[package]]
-name = "registry-canister"
-version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=5ff84f5b82fc675683d6b70c4e1a81678813633a#5ff84f5b82fc675683d6b70c4e1a81678813633a"
-dependencies = [
- "build-info",
- "build-info-build",
- "candid",
- "dfn_candid",
- "dfn_core",
- "dfn_http_metrics",
- "futures",
- "ic-base-types",
- "ic-cdk",
- "ic-certified-map",
- "ic-crypto-node-key-validation",
- "ic-crypto-sha2",
- "ic-crypto-utils-basic-sig",
- "ic-crypto-utils-ni-dkg",
- "ic-management-canister-types",
- "ic-metrics-encoder",
- "ic-nervous-system-common",
- "ic-nervous-system-common-build-metadata",
- "ic-nns-common",
- "ic-nns-constants",
- "ic-protobuf",
- "ic-registry-canister-api",
- "ic-registry-keys",
- "ic-registry-node-provider-rewards",
- "ic-registry-routing-table",
- "ic-registry-subnet-features",
- "ic-registry-subnet-type",
- "ic-registry-transport",
- "ic-types",
- "idna 1.0.2",
- "ipnet",
- "lazy_static",
- "leb128",
- "on_wire",
- "prost",
- "serde",
- "url",
-]
 
 [[package]]
 name = "rend"
@@ -6247,15 +5582,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
-]
-
-[[package]]
-name = "rusticata-macros"
-version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
-dependencies = [
- "nom",
 ]
 
 [[package]]
@@ -7063,17 +6389,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "synstructure"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.77",
-]
-
-[[package]]
 name = "system-configuration"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7246,16 +6561,6 @@ dependencies = [
  "unicode-normalization",
  "wasm-bindgen",
  "zeroize",
-]
-
-[[package]]
-name = "tinystr"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
-dependencies = [
- "displaydoc",
- "zerovec",
 ]
 
 [[package]]
@@ -7564,28 +6869,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22784dbdf76fdde8af1aeda5622b546b422b6fc585325248a2bf9f5e41e94d6c"
 dependencies = [
  "form_urlencoded",
- "idna 0.5.0",
+ "idna",
  "percent-encoding",
  "serde",
 ]
-
-[[package]]
-name = "utf16_iter"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
 
 [[package]]
 name = "utf8-width"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86bd8d4e895da8537e5315b8254664e6b769c4ff3db18321b297a1e7004392e3"
-
-[[package]]
-name = "utf8_iter"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utf8parse"
@@ -8054,18 +7347,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "write16"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
-
-[[package]]
-name = "writeable"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
-
-[[package]]
 name = "wsl"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8078,23 +7359,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
-]
-
-[[package]]
-name = "x509-parser"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcbc162f30700d6f3f82a24bf7cc62ffe7caea42c0b2cba8bf7f3ae50cf51f69"
-dependencies = [
- "asn1-rs",
- "data-encoding",
- "der-parser",
- "lazy_static",
- "nom",
- "oid-registry",
- "rusticata-macros",
- "thiserror",
- "time",
 ]
 
 [[package]]
@@ -8120,30 +7384,6 @@ name = "yansi"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
-
-[[package]]
-name = "yoke"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c5b1314b079b0930c31e3af543d8ee1757b1951ae1e1565ec704403a7240ca5"
-dependencies = [
- "serde",
- "stable_deref_trait",
- "yoke-derive",
- "zerofrom",
-]
-
-[[package]]
-name = "yoke-derive"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28cc31741b18cb6f1d5ff12f5b7523e3d6eb0852bbbad19d73905511d9849b95"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.77",
- "synstructure",
-]
 
 [[package]]
 name = "zbus"
@@ -8202,27 +7442,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "zerofrom"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91ec111ce797d0e0784a1116d0ddcdbea84322cd79e5d5ad173daeba4f93ab55"
-dependencies = [
- "zerofrom-derive",
-]
-
-[[package]]
-name = "zerofrom-derive"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ea7b4a3637ea8669cedf0f1fd5c286a17f3de97b8dd5a70a6c167a1730e63a5"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.77",
- "synstructure",
-]
-
-[[package]]
 name = "zeroize"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8236,28 +7455,6 @@ name = "zeroize_derive"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.77",
-]
-
-[[package]]
-name = "zerovec"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa2b893d79df23bfb12d5461018d408ea19dfafe76c2c7ef6d4eba614f8ff079"
-dependencies = [
- "yoke",
- "zerofrom",
- "zerovec-derive",
-]
-
-[[package]]
-name = "zerovec-derive"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,11 +34,11 @@ slog = "^2.7.0"
 tempfile = "3.12.0"
 tokio = { version = "^1.36.0", features = ["rt-multi-thread"] }
 url = "^2.4.1"
-ic-http-utils = { git = "https://github.com/dfinity/ic", rev = "5ff84f5b82fc675683d6b70c4e1a81678813633a" }
-ic-icp-index = { git = "https://github.com/dfinity/ic", rev = "5ff84f5b82fc675683d6b70c4e1a81678813633a" }
-ic-icrc1-index-ng = { git = "https://github.com/dfinity/ic", rev = "5ff84f5b82fc675683d6b70c4e1a81678813633a" }
-ic-icrc1-ledger = { git = "https://github.com/dfinity/ic", rev = "5ff84f5b82fc675683d6b70c4e1a81678813633a" }
-ic-sns-cli = { git = "https://github.com/dfinity/ic", rev = "5ff84f5b82fc675683d6b70c4e1a81678813633a" }
+ic-http-utils = { git = "https://github.com/dfinity/ic", rev = "f7e561c00a2745f946372f5166fd7968fa664f53" }
+ic-icp-index = { git = "https://github.com/dfinity/ic", rev = "f7e561c00a2745f946372f5166fd7968fa664f53" }
+ic-icrc1-index-ng = { git = "https://github.com/dfinity/ic", rev = "f7e561c00a2745f946372f5166fd7968fa664f53" }
+ic-icrc1-ledger = { git = "https://github.com/dfinity/ic", rev = "f7e561c00a2745f946372f5166fd7968fa664f53" }
+ic-sns-cli = { git = "https://github.com/dfinity/ic", rev = "f7e561c00a2745f946372f5166fd7968fa664f53" }
 serde_json = "1.0.79"
 
 # Config for 'cargo dist'

--- a/extensions/nns/build.rs
+++ b/extensions/nns/build.rs
@@ -1,7 +1,7 @@
 use std::env;
 use std::path::PathBuf;
 
-const REPLICA_REV: &str = "5ff84f5b82fc675683d6b70c4e1a81678813633a";
+const REPLICA_REV: &str = "f7e561c00a2745f946372f5166fd7968fa664f53";
 
 const BINARY_DEPENDENCIES: &[(&str, &str)] = &[
     // (downloaded binary name, renamed binary name)

--- a/extensions/sns/build.rs
+++ b/extensions/sns/build.rs
@@ -1,7 +1,7 @@
 use std::env;
 use std::path::PathBuf;
 
-const REPLICA_REV: &str = "5ff84f5b82fc675683d6b70c4e1a81678813633a";
+const REPLICA_REV: &str = "f7e561c00a2745f946372f5166fd7968fa664f53";
 
 const BINARY_DEPENDENCIES: &[(&str, &str)] = &[
     // (downloaded binary name, renamed binary name)


### PR DESCRIPTION
This updates the replica rev to the latest version, since the previous version of the DFX NNS extension used a version of NNS Governance that removed support for some proposal types. The IC monorepo version is also updated as it needs to be kept in sync with the replica rev.