### PR TITLE
fix: load dfx.json with extension-defined canister type

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -8,7 +8,6 @@ on:
   push:
     branches:
       - main
-      - ens/sdk-1832-load-dfx-json-with-extension-canister
   pull_request:
 
 jobs:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -8,6 +8,7 @@ on:
   push:
     branches:
       - main
+      - ens/sdk-1832-load-dfx-json-with-extension-canister
   pull_request:
 
 jobs:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1374,9 +1374,9 @@ dependencies = [
  "handlebars",
  "hex",
  "humantime-serde",
- "ic-agent 0.38.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-agent 0.38.2",
  "ic-identity-hsm",
- "ic-utils 0.38.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-utils 0.38.2",
  "itertools 0.10.5",
  "k256 0.11.6",
  "keyring",
@@ -2502,12 +2502,10 @@ dependencies = [
 
 [[package]]
 name = "ic-agent"
-version = "0.38.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17a656d3b25007f59ba0700e65b332efd56d5dbfc6014994000ab3dbb221f54a"
+version = "0.38.0"
+source = "git+https://github.com/dfinity/agent-rs?rev=729398880545a1f49a4c6286d0dd0c94254b236f#729398880545a1f49a4c6286d0dd0c94254b236f"
 dependencies = [
  "async-lock 3.4.0",
- "async-trait",
  "backoff",
  "cached",
  "candid",
@@ -2517,7 +2515,7 @@ dependencies = [
  "http 1.1.0",
  "http-body 1.0.1",
  "ic-certification",
- "ic-transport-types 0.38.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-transport-types 0.38.0",
  "ic-verify-bls-signature",
  "k256 0.13.4",
  "leb128",
@@ -2539,14 +2537,14 @@ dependencies = [
  "thiserror",
  "time",
  "tokio",
- "tower-service",
  "url",
 ]
 
 [[package]]
 name = "ic-agent"
 version = "0.38.2"
-source = "git+https://github.com/dfinity/agent-rs?rev=4642e30ab6cf148ad94bda0c12f1b9330377de36#4642e30ab6cf148ad94bda0c12f1b9330377de36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17a656d3b25007f59ba0700e65b332efd56d5dbfc6014994000ab3dbb221f54a"
 dependencies = [
  "async-lock 3.4.0",
  "async-trait",
@@ -2559,7 +2557,7 @@ dependencies = [
  "http 1.1.0",
  "http-body 1.0.1",
  "ic-certification",
- "ic-transport-types 0.38.2 (git+https://github.com/dfinity/agent-rs?rev=4642e30ab6cf148ad94bda0c12f1b9330377de36)",
+ "ic-transport-types 0.38.2",
  "ic-verify-bls-signature",
  "k256 0.13.4",
  "leb128",
@@ -3002,7 +3000,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccb4b9a8628378f958d63526d322486a9bb3fde81bccf0ac2fa720b8b241f068"
 dependencies = [
  "hex",
- "ic-agent 0.38.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-agent 0.38.2",
  "pkcs11",
  "sha2 0.10.8",
  "simple_asn1",
@@ -3791,9 +3789,8 @@ dependencies = [
 
 [[package]]
 name = "ic-transport-types"
-version = "0.38.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "894b183f280e87b29aac98e7de0972cf632435e1f0a462969d9f5e0ccacc4d25"
+version = "0.38.0"
+source = "git+https://github.com/dfinity/agent-rs?rev=729398880545a1f49a4c6286d0dd0c94254b236f#729398880545a1f49a4c6286d0dd0c94254b236f"
 dependencies = [
  "candid",
  "hex",
@@ -3801,7 +3798,6 @@ dependencies = [
  "leb128",
  "serde",
  "serde_bytes",
- "serde_cbor",
  "serde_repr",
  "sha2 0.10.8",
  "thiserror",
@@ -3810,7 +3806,8 @@ dependencies = [
 [[package]]
 name = "ic-transport-types"
 version = "0.38.2"
-source = "git+https://github.com/dfinity/agent-rs?rev=4642e30ab6cf148ad94bda0c12f1b9330377de36#4642e30ab6cf148ad94bda0c12f1b9330377de36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "894b183f280e87b29aac98e7de0972cf632435e1f0a462969d9f5e0ccacc4d25"
 dependencies = [
  "candid",
  "hex",
@@ -3874,14 +3871,13 @@ dependencies = [
 
 [[package]]
 name = "ic-utils"
-version = "0.38.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c1f79ec080e22a44d5f2f3f1176979a77ad1b5cd2681f878aa4b85dbe8b4cf1"
+version = "0.38.0"
+source = "git+https://github.com/dfinity/agent-rs?rev=729398880545a1f49a4c6286d0dd0c94254b236f#729398880545a1f49a4c6286d0dd0c94254b236f"
 dependencies = [
  "async-trait",
  "candid",
  "futures-util",
- "ic-agent 0.38.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-agent 0.38.0",
  "once_cell",
  "semver",
  "serde",
@@ -3897,12 +3893,13 @@ dependencies = [
 [[package]]
 name = "ic-utils"
 version = "0.38.2"
-source = "git+https://github.com/dfinity/agent-rs?rev=4642e30ab6cf148ad94bda0c12f1b9330377de36#4642e30ab6cf148ad94bda0c12f1b9330377de36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c1f79ec080e22a44d5f2f3f1176979a77ad1b5cd2681f878aa4b85dbe8b4cf1"
 dependencies = [
  "async-trait",
  "candid",
  "futures-util",
- "ic-agent 0.38.2 (git+https://github.com/dfinity/agent-rs?rev=4642e30ab6cf148ad94bda0c12f1b9330377de36)",
+ "ic-agent 0.38.2",
  "once_cell",
  "semver",
  "serde",
@@ -4596,13 +4593,13 @@ dependencies = [
  "fn-error-context",
  "futures-util",
  "hex",
- "ic-agent 0.38.2 (git+https://github.com/dfinity/agent-rs?rev=4642e30ab6cf148ad94bda0c12f1b9330377de36)",
+ "ic-agent 0.38.0",
  "ic-http-utils",
  "ic-icp-index",
  "ic-icrc1-index-ng",
  "ic-icrc1-ledger",
  "ic-sns-cli",
- "ic-utils 0.38.2 (git+https://github.com/dfinity/agent-rs?rev=4642e30ab6cf148ad94bda0c12f1b9330377de36)",
+ "ic-utils 0.38.0",
  "reqwest 0.11.27",
  "rust_decimal",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1357,7 +1357,7 @@ dependencies = [
 [[package]]
 name = "dfx-core"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/sdk?rev=10391754ccd8d5eb92890f896369bd7c8b62af56#10391754ccd8d5eb92890f896369bd7c8b62af56"
+source = "git+https://github.com/dfinity/sdk?rev=7c5778a4b3c36806353f3f93ea04c7a76c42dea1#7c5778a4b3c36806353f3f93ea04c7a76c42dea1"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -1374,9 +1374,9 @@ dependencies = [
  "handlebars",
  "hex",
  "humantime-serde",
- "ic-agent 0.38.2",
+ "ic-agent 0.38.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "ic-identity-hsm",
- "ic-utils 0.38.2",
+ "ic-utils 0.38.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.10.5",
  "k256 0.11.6",
  "keyring",
@@ -2517,7 +2517,49 @@ dependencies = [
  "http 1.1.0",
  "http-body 1.0.1",
  "ic-certification",
- "ic-transport-types 0.38.2",
+ "ic-transport-types 0.38.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-verify-bls-signature",
+ "k256 0.13.4",
+ "leb128",
+ "p256",
+ "pem 3.0.4",
+ "pkcs8 0.10.2",
+ "rand",
+ "rangemap",
+ "reqwest 0.12.8",
+ "ring 0.17.8",
+ "rustls-webpki 0.102.8",
+ "sec1 0.7.3",
+ "serde",
+ "serde_bytes",
+ "serde_cbor",
+ "serde_repr",
+ "sha2 0.10.8",
+ "simple_asn1",
+ "thiserror",
+ "time",
+ "tokio",
+ "tower-service",
+ "url",
+]
+
+[[package]]
+name = "ic-agent"
+version = "0.38.2"
+source = "git+https://github.com/dfinity/agent-rs?rev=4642e30ab6cf148ad94bda0c12f1b9330377de36#4642e30ab6cf148ad94bda0c12f1b9330377de36"
+dependencies = [
+ "async-lock 3.4.0",
+ "async-trait",
+ "backoff",
+ "cached",
+ "candid",
+ "ed25519-consensus",
+ "futures-util",
+ "hex",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "ic-certification",
+ "ic-transport-types 0.38.2 (git+https://github.com/dfinity/agent-rs?rev=4642e30ab6cf148ad94bda0c12f1b9330377de36)",
  "ic-verify-bls-signature",
  "k256 0.13.4",
  "leb128",
@@ -2960,7 +3002,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccb4b9a8628378f958d63526d322486a9bb3fde81bccf0ac2fa720b8b241f068"
 dependencies = [
  "hex",
- "ic-agent 0.38.2",
+ "ic-agent 0.38.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkcs11",
  "sha2 0.10.8",
  "simple_asn1",
@@ -3766,6 +3808,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "ic-transport-types"
+version = "0.38.2"
+source = "git+https://github.com/dfinity/agent-rs?rev=4642e30ab6cf148ad94bda0c12f1b9330377de36#4642e30ab6cf148ad94bda0c12f1b9330377de36"
+dependencies = [
+ "candid",
+ "hex",
+ "ic-certification",
+ "leb128",
+ "serde",
+ "serde_bytes",
+ "serde_cbor",
+ "serde_repr",
+ "sha2 0.10.8",
+ "thiserror",
+]
+
+[[package]]
 name = "ic-types"
 version = "0.9.0"
 source = "git+https://github.com/dfinity/ic?rev=61f05b60fb3464cec774da4dc81aca0dc4fa8366#61f05b60fb3464cec774da4dc81aca0dc4fa8366"
@@ -3822,7 +3881,28 @@ dependencies = [
  "async-trait",
  "candid",
  "futures-util",
- "ic-agent 0.38.2",
+ "ic-agent 0.38.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "once_cell",
+ "semver",
+ "serde",
+ "serde_bytes",
+ "sha2 0.10.8",
+ "strum",
+ "strum_macros",
+ "thiserror",
+ "time",
+ "tokio",
+]
+
+[[package]]
+name = "ic-utils"
+version = "0.38.2"
+source = "git+https://github.com/dfinity/agent-rs?rev=4642e30ab6cf148ad94bda0c12f1b9330377de36#4642e30ab6cf148ad94bda0c12f1b9330377de36"
+dependencies = [
+ "async-trait",
+ "candid",
+ "futures-util",
+ "ic-agent 0.38.2 (git+https://github.com/dfinity/agent-rs?rev=4642e30ab6cf148ad94bda0c12f1b9330377de36)",
  "once_cell",
  "semver",
  "serde",
@@ -4516,13 +4596,13 @@ dependencies = [
  "fn-error-context",
  "futures-util",
  "hex",
- "ic-agent 0.38.2",
+ "ic-agent 0.38.2 (git+https://github.com/dfinity/agent-rs?rev=4642e30ab6cf148ad94bda0c12f1b9330377de36)",
  "ic-http-utils",
  "ic-icp-index",
  "ic-icrc1-index-ng",
  "ic-icrc1-ledger",
  "ic-sns-cli",
- "ic-utils 0.38.2",
+ "ic-utils 0.38.2 (git+https://github.com/dfinity/agent-rs?rev=4642e30ab6cf148ad94bda0c12f1b9330377de36)",
  "reqwest 0.11.27",
  "rust_decimal",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1356,8 +1356,8 @@ dependencies = [
 
 [[package]]
 name = "dfx-core"
-version = "0.0.1"
-source = "git+https://github.com/dfinity/sdk?rev=993ae6df38caef8aae5291570b78954334d16b21#993ae6df38caef8aae5291570b78954334d16b21"
+version = "0.1.0"
+source = "git+https://github.com/dfinity/sdk?rev=10391754ccd8d5eb92890f896369bd7c8b62af56#10391754ccd8d5eb92890f896369bd7c8b62af56"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -1374,9 +1374,9 @@ dependencies = [
  "handlebars",
  "hex",
  "humantime-serde",
- "ic-agent 0.37.1 (git+https://github.com/dfinity/agent-rs?rev=6e11a350112f9b907c4d590d8217f340e153d898)",
+ "ic-agent 0.38.2",
  "ic-identity-hsm",
- "ic-utils 0.37.1",
+ "ic-utils 0.38.2",
  "itertools 0.10.5",
  "k256 0.11.6",
  "keyring",
@@ -2474,7 +2474,7 @@ dependencies = [
  "hyper-rustls 0.27.3",
  "hyper-util",
  "ic-certification",
- "ic-transport-types 0.37.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-transport-types 0.37.1",
  "ic-verify-bls-signature",
  "k256 0.13.4",
  "leb128",
@@ -2502,10 +2502,12 @@ dependencies = [
 
 [[package]]
 name = "ic-agent"
-version = "0.37.1"
-source = "git+https://github.com/dfinity/agent-rs?rev=6e11a350112f9b907c4d590d8217f340e153d898#6e11a350112f9b907c4d590d8217f340e153d898"
+version = "0.38.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17a656d3b25007f59ba0700e65b332efd56d5dbfc6014994000ab3dbb221f54a"
 dependencies = [
  "async-lock 3.4.0",
+ "async-trait",
  "backoff",
  "cached",
  "candid",
@@ -2515,7 +2517,7 @@ dependencies = [
  "http 1.1.0",
  "http-body 1.0.1",
  "ic-certification",
- "ic-transport-types 0.37.1 (git+https://github.com/dfinity/agent-rs?rev=6e11a350112f9b907c4d590d8217f340e153d898)",
+ "ic-transport-types 0.38.2",
  "ic-verify-bls-signature",
  "k256 0.13.4",
  "leb128",
@@ -2537,6 +2539,7 @@ dependencies = [
  "thiserror",
  "time",
  "tokio",
+ "tower-service",
  "url",
 ]
 
@@ -2952,11 +2955,12 @@ dependencies = [
 
 [[package]]
 name = "ic-identity-hsm"
-version = "0.37.1"
-source = "git+https://github.com/dfinity/agent-rs?rev=6e11a350112f9b907c4d590d8217f340e153d898#6e11a350112f9b907c4d590d8217f340e153d898"
+version = "0.38.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccb4b9a8628378f958d63526d322486a9bb3fde81bccf0ac2fa720b8b241f068"
 dependencies = [
  "hex",
- "ic-agent 0.37.1 (git+https://github.com/dfinity/agent-rs?rev=6e11a350112f9b907c4d590d8217f340e153d898)",
+ "ic-agent 0.38.2",
  "pkcs11",
  "sha2 0.10.8",
  "simple_asn1",
@@ -3058,7 +3062,7 @@ source = "git+https://github.com/dfinity/ic?rev=61f05b60fb3464cec774da4dc81aca0d
 dependencies = [
  "anyhow",
  "candid",
- "ic-agent 0.37.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-agent 0.37.1",
  "ic-base-types",
  "ic-nervous-system-clients",
  "ic-nns-common",
@@ -3423,7 +3427,7 @@ dependencies = [
  "clap 4.5.20",
  "futures",
  "hex",
- "ic-agent 0.37.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-agent 0.37.1",
  "ic-base-types",
  "ic-crypto-sha2",
  "ic-nervous-system-agent",
@@ -3745,8 +3749,9 @@ dependencies = [
 
 [[package]]
 name = "ic-transport-types"
-version = "0.37.1"
-source = "git+https://github.com/dfinity/agent-rs?rev=6e11a350112f9b907c4d590d8217f340e153d898#6e11a350112f9b907c4d590d8217f340e153d898"
+version = "0.38.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "894b183f280e87b29aac98e7de0972cf632435e1f0a462969d9f5e0ccacc4d25"
 dependencies = [
  "candid",
  "hex",
@@ -3754,6 +3759,7 @@ dependencies = [
  "leb128",
  "serde",
  "serde_bytes",
+ "serde_cbor",
  "serde_repr",
  "sha2 0.10.8",
  "thiserror",
@@ -3809,13 +3815,14 @@ dependencies = [
 
 [[package]]
 name = "ic-utils"
-version = "0.37.1"
-source = "git+https://github.com/dfinity/agent-rs?rev=6e11a350112f9b907c4d590d8217f340e153d898#6e11a350112f9b907c4d590d8217f340e153d898"
+version = "0.38.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c1f79ec080e22a44d5f2f3f1176979a77ad1b5cd2681f878aa4b85dbe8b4cf1"
 dependencies = [
  "async-trait",
  "candid",
  "futures-util",
- "ic-agent 0.37.1 (git+https://github.com/dfinity/agent-rs?rev=6e11a350112f9b907c4d590d8217f340e153d898)",
+ "ic-agent 0.38.2",
  "once_cell",
  "semver",
  "serde",
@@ -4509,13 +4516,13 @@ dependencies = [
  "fn-error-context",
  "futures-util",
  "hex",
- "ic-agent 0.37.1 (git+https://github.com/dfinity/agent-rs?rev=6e11a350112f9b907c4d590d8217f340e153d898)",
+ "ic-agent 0.38.2",
  "ic-http-utils",
  "ic-icp-index",
  "ic-icrc1-index-ng",
  "ic-icrc1-ledger",
  "ic-sns-cli",
- "ic-utils 0.37.1",
+ "ic-utils 0.38.2",
  "reqwest 0.11.27",
  "rust_decimal",
  "serde",
@@ -4960,9 +4967,9 @@ dependencies = [
  "base64 0.13.1",
  "candid",
  "hex",
- "ic-agent 0.37.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-agent 0.37.1",
  "ic-cdk",
- "ic-transport-types 0.37.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-transport-types 0.37.1",
  "reqwest 0.12.8",
  "schemars",
  "serde",
@@ -6278,7 +6285,7 @@ dependencies = [
  "dfx-extensions-utils",
  "fn-error-context",
  "futures-util",
- "ic-agent 0.37.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-agent 0.37.1",
  "ic-sns-cli",
  "serde_json",
  "slog",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1356,8 +1356,8 @@ dependencies = [
 
 [[package]]
 name = "dfx-core"
-version = "0.1.0"
-source = "git+https://github.com/dfinity/sdk?rev=10391754ccd8d5eb92890f896369bd7c8b62af56#10391754ccd8d5eb92890f896369bd7c8b62af56"
+version = "0.0.1"
+source = "git+https://github.com/dfinity/sdk?rev=993ae6df38caef8aae5291570b78954334d16b21#993ae6df38caef8aae5291570b78954334d16b21"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -1374,9 +1374,9 @@ dependencies = [
  "handlebars",
  "hex",
  "humantime-serde",
- "ic-agent 0.38.2",
+ "ic-agent 0.37.1 (git+https://github.com/dfinity/agent-rs?rev=6e11a350112f9b907c4d590d8217f340e153d898)",
  "ic-identity-hsm",
- "ic-utils 0.38.2",
+ "ic-utils 0.37.1",
  "itertools 0.10.5",
  "k256 0.11.6",
  "keyring",
@@ -2474,7 +2474,7 @@ dependencies = [
  "hyper-rustls 0.27.3",
  "hyper-util",
  "ic-certification",
- "ic-transport-types 0.37.1",
+ "ic-transport-types 0.37.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ic-verify-bls-signature",
  "k256 0.13.4",
  "leb128",
@@ -2502,12 +2502,10 @@ dependencies = [
 
 [[package]]
 name = "ic-agent"
-version = "0.38.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17a656d3b25007f59ba0700e65b332efd56d5dbfc6014994000ab3dbb221f54a"
+version = "0.37.1"
+source = "git+https://github.com/dfinity/agent-rs?rev=6e11a350112f9b907c4d590d8217f340e153d898#6e11a350112f9b907c4d590d8217f340e153d898"
 dependencies = [
  "async-lock 3.4.0",
- "async-trait",
  "backoff",
  "cached",
  "candid",
@@ -2517,7 +2515,7 @@ dependencies = [
  "http 1.1.0",
  "http-body 1.0.1",
  "ic-certification",
- "ic-transport-types 0.38.2",
+ "ic-transport-types 0.37.1 (git+https://github.com/dfinity/agent-rs?rev=6e11a350112f9b907c4d590d8217f340e153d898)",
  "ic-verify-bls-signature",
  "k256 0.13.4",
  "leb128",
@@ -2539,7 +2537,6 @@ dependencies = [
  "thiserror",
  "time",
  "tokio",
- "tower-service",
  "url",
 ]
 
@@ -2955,12 +2952,11 @@ dependencies = [
 
 [[package]]
 name = "ic-identity-hsm"
-version = "0.38.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccb4b9a8628378f958d63526d322486a9bb3fde81bccf0ac2fa720b8b241f068"
+version = "0.37.1"
+source = "git+https://github.com/dfinity/agent-rs?rev=6e11a350112f9b907c4d590d8217f340e153d898#6e11a350112f9b907c4d590d8217f340e153d898"
 dependencies = [
  "hex",
- "ic-agent 0.38.2",
+ "ic-agent 0.37.1 (git+https://github.com/dfinity/agent-rs?rev=6e11a350112f9b907c4d590d8217f340e153d898)",
  "pkcs11",
  "sha2 0.10.8",
  "simple_asn1",
@@ -3062,7 +3058,7 @@ source = "git+https://github.com/dfinity/ic?rev=61f05b60fb3464cec774da4dc81aca0d
 dependencies = [
  "anyhow",
  "candid",
- "ic-agent 0.37.1",
+ "ic-agent 0.37.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ic-base-types",
  "ic-nervous-system-clients",
  "ic-nns-common",
@@ -3427,7 +3423,7 @@ dependencies = [
  "clap 4.5.20",
  "futures",
  "hex",
- "ic-agent 0.37.1",
+ "ic-agent 0.37.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ic-base-types",
  "ic-crypto-sha2",
  "ic-nervous-system-agent",
@@ -3749,9 +3745,8 @@ dependencies = [
 
 [[package]]
 name = "ic-transport-types"
-version = "0.38.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "894b183f280e87b29aac98e7de0972cf632435e1f0a462969d9f5e0ccacc4d25"
+version = "0.37.1"
+source = "git+https://github.com/dfinity/agent-rs?rev=6e11a350112f9b907c4d590d8217f340e153d898#6e11a350112f9b907c4d590d8217f340e153d898"
 dependencies = [
  "candid",
  "hex",
@@ -3759,7 +3754,6 @@ dependencies = [
  "leb128",
  "serde",
  "serde_bytes",
- "serde_cbor",
  "serde_repr",
  "sha2 0.10.8",
  "thiserror",
@@ -3815,14 +3809,13 @@ dependencies = [
 
 [[package]]
 name = "ic-utils"
-version = "0.38.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c1f79ec080e22a44d5f2f3f1176979a77ad1b5cd2681f878aa4b85dbe8b4cf1"
+version = "0.37.1"
+source = "git+https://github.com/dfinity/agent-rs?rev=6e11a350112f9b907c4d590d8217f340e153d898#6e11a350112f9b907c4d590d8217f340e153d898"
 dependencies = [
  "async-trait",
  "candid",
  "futures-util",
- "ic-agent 0.38.2",
+ "ic-agent 0.37.1 (git+https://github.com/dfinity/agent-rs?rev=6e11a350112f9b907c4d590d8217f340e153d898)",
  "once_cell",
  "semver",
  "serde",
@@ -4516,13 +4509,13 @@ dependencies = [
  "fn-error-context",
  "futures-util",
  "hex",
- "ic-agent 0.38.2",
+ "ic-agent 0.37.1 (git+https://github.com/dfinity/agent-rs?rev=6e11a350112f9b907c4d590d8217f340e153d898)",
  "ic-http-utils",
  "ic-icp-index",
  "ic-icrc1-index-ng",
  "ic-icrc1-ledger",
  "ic-sns-cli",
- "ic-utils 0.38.2",
+ "ic-utils 0.37.1",
  "reqwest 0.11.27",
  "rust_decimal",
  "serde",
@@ -4967,9 +4960,9 @@ dependencies = [
  "base64 0.13.1",
  "candid",
  "hex",
- "ic-agent 0.37.1",
+ "ic-agent 0.37.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ic-cdk",
- "ic-transport-types 0.37.1",
+ "ic-transport-types 0.37.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.12.8",
  "schemars",
  "serde",
@@ -6285,7 +6278,7 @@ dependencies = [
  "dfx-extensions-utils",
  "fn-error-context",
  "futures-util",
- "ic-agent 0.37.1",
+ "ic-agent 0.37.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ic-sns-cli",
  "serde_json",
  "slog",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1357,7 +1357,7 @@ dependencies = [
 [[package]]
 name = "dfx-core"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/sdk?rev=7c5778a4b3c36806353f3f93ea04c7a76c42dea1#7c5778a4b3c36806353f3f93ea04c7a76c42dea1"
+source = "git+https://github.com/dfinity/sdk?rev=72cb25775dd9edec0a01b6ae3d4763485bd0a72e#72cb25775dd9edec0a01b6ae3d4763485bd0a72e"
 dependencies = [
  "aes-gcm",
  "argon2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1356,8 +1356,9 @@ dependencies = [
 
 [[package]]
 name = "dfx-core"
-version = "0.1.0"
-source = "git+https://github.com/dfinity/sdk?rev=72cb25775dd9edec0a01b6ae3d4763485bd0a72e#72cb25775dd9edec0a01b6ae3d4763485bd0a72e"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e454e8c92953264dfd491c0850fe2f4503fcdaae2ad267fdb23e529d3612e12d"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -1374,9 +1375,9 @@ dependencies = [
  "handlebars",
  "hex",
  "humantime-serde",
- "ic-agent 0.38.2",
+ "ic-agent 0.38.0",
  "ic-identity-hsm",
- "ic-utils 0.38.2",
+ "ic-utils 0.38.0",
  "itertools 0.10.5",
  "k256 0.11.6",
  "keyring",
@@ -2503,51 +2504,10 @@ dependencies = [
 [[package]]
 name = "ic-agent"
 version = "0.38.0"
-source = "git+https://github.com/dfinity/agent-rs?rev=729398880545a1f49a4c6286d0dd0c94254b236f#729398880545a1f49a4c6286d0dd0c94254b236f"
-dependencies = [
- "async-lock 3.4.0",
- "backoff",
- "cached",
- "candid",
- "ed25519-consensus",
- "futures-util",
- "hex",
- "http 1.1.0",
- "http-body 1.0.1",
- "ic-certification",
- "ic-transport-types 0.38.0",
- "ic-verify-bls-signature",
- "k256 0.13.4",
- "leb128",
- "p256",
- "pem 3.0.4",
- "pkcs8 0.10.2",
- "rand",
- "rangemap",
- "reqwest 0.12.8",
- "ring 0.17.8",
- "rustls-webpki 0.102.8",
- "sec1 0.7.3",
- "serde",
- "serde_bytes",
- "serde_cbor",
- "serde_repr",
- "sha2 0.10.8",
- "simple_asn1",
- "thiserror",
- "time",
- "tokio",
- "url",
-]
-
-[[package]]
-name = "ic-agent"
-version = "0.38.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17a656d3b25007f59ba0700e65b332efd56d5dbfc6014994000ab3dbb221f54a"
+checksum = "def8c34690d68caa452486af1fff4782d2f5a9d4c5b4e0e1afca648c616fa380"
 dependencies = [
  "async-lock 3.4.0",
- "async-trait",
  "backoff",
  "cached",
  "candid",
@@ -2579,7 +2539,6 @@ dependencies = [
  "thiserror",
  "time",
  "tokio",
- "tower-service",
  "url",
 ]
 
@@ -2995,12 +2954,12 @@ dependencies = [
 
 [[package]]
 name = "ic-identity-hsm"
-version = "0.38.2"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccb4b9a8628378f958d63526d322486a9bb3fde81bccf0ac2fa720b8b241f068"
+checksum = "fe9975ba49e50ccf10d8268b168b9a35da165904f56725a333e8294d7e5f1d92"
 dependencies = [
  "hex",
- "ic-agent 0.38.2",
+ "ic-agent 0.38.0",
  "pkcs11",
  "sha2 0.10.8",
  "simple_asn1",
@@ -3789,22 +3748,6 @@ dependencies = [
 
 [[package]]
 name = "ic-transport-types"
-version = "0.38.0"
-source = "git+https://github.com/dfinity/agent-rs?rev=729398880545a1f49a4c6286d0dd0c94254b236f#729398880545a1f49a4c6286d0dd0c94254b236f"
-dependencies = [
- "candid",
- "hex",
- "ic-certification",
- "leb128",
- "serde",
- "serde_bytes",
- "serde_repr",
- "sha2 0.10.8",
- "thiserror",
-]
-
-[[package]]
-name = "ic-transport-types"
 version = "0.38.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "894b183f280e87b29aac98e7de0972cf632435e1f0a462969d9f5e0ccacc4d25"
@@ -3872,34 +3815,13 @@ dependencies = [
 [[package]]
 name = "ic-utils"
 version = "0.38.0"
-source = "git+https://github.com/dfinity/agent-rs?rev=729398880545a1f49a4c6286d0dd0c94254b236f#729398880545a1f49a4c6286d0dd0c94254b236f"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75135bc8838398f2b4a512b900ee1d58fbf34bdedb74aedc0ae772e785535814"
 dependencies = [
  "async-trait",
  "candid",
  "futures-util",
  "ic-agent 0.38.0",
- "once_cell",
- "semver",
- "serde",
- "serde_bytes",
- "sha2 0.10.8",
- "strum",
- "strum_macros",
- "thiserror",
- "time",
- "tokio",
-]
-
-[[package]]
-name = "ic-utils"
-version = "0.38.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c1f79ec080e22a44d5f2f3f1176979a77ad1b5cd2681f878aa4b85dbe8b4cf1"
-dependencies = [
- "async-trait",
- "candid",
- "futures-util",
- "ic-agent 0.38.2",
  "once_cell",
  "semver",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "Apache-2.0"
 repository = "https://github.com/dfinity/dfx-extensions"
 
 [workspace.dependencies]
-dfx-core = { git = "https://github.com/dfinity/sdk", rev = "10391754ccd8d5eb92890f896369bd7c8b62af56" }
+dfx-core = { git = "https://github.com/dfinity/sdk", rev = "993ae6df38caef8aae5291570b78954334d16b21" }
 dfx-extensions-utils.path = "./extensions-utils"
 
 anyhow = "^1"
@@ -21,8 +21,8 @@ flate2 = { version = "1.0.25", default-features = false, features = [
 ] }
 fn-error-context = "0.2.1"
 futures-util = "0.3.28"
-ic-agent = "0.38" # { git = "https://github.com/dfinity/agent-rs", rev = "6e11a350112f9b907c4d590d8217f340e153d898" }
-ic-utils = "0.38" # { git = "https://github.com/dfinity/agent-rs", rev = "6e11a350112f9b907c4d590d8217f340e153d898" }
+ic-agent = { git = "https://github.com/dfinity/agent-rs", rev = "6e11a350112f9b907c4d590d8217f340e153d898" }
+ic-utils = { git = "https://github.com/dfinity/agent-rs", rev = "6e11a350112f9b907c4d590d8217f340e153d898" }
 reqwest = { version = "^0.11.22", default-features = false, features = [
     "blocking",
     "json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "Apache-2.0"
 repository = "https://github.com/dfinity/dfx-extensions"
 
 [workspace.dependencies]
-dfx-core = { git = "https://github.com/dfinity/sdk", rev = "993ae6df38caef8aae5291570b78954334d16b21" }
+dfx-core = { git = "https://github.com/dfinity/sdk", rev = "10391754ccd8d5eb92890f896369bd7c8b62af56" }
 dfx-extensions-utils.path = "./extensions-utils"
 
 anyhow = "^1"
@@ -21,8 +21,8 @@ flate2 = { version = "1.0.25", default-features = false, features = [
 ] }
 fn-error-context = "0.2.1"
 futures-util = "0.3.28"
-ic-agent = { git = "https://github.com/dfinity/agent-rs", rev = "6e11a350112f9b907c4d590d8217f340e153d898" }
-ic-utils = { git = "https://github.com/dfinity/agent-rs", rev = "6e11a350112f9b907c4d590d8217f340e153d898" }
+ic-agent = "0.38" # { git = "https://github.com/dfinity/agent-rs", rev = "6e11a350112f9b907c4d590d8217f340e153d898" }
+ic-utils = "0.38" # { git = "https://github.com/dfinity/agent-rs", rev = "6e11a350112f9b907c4d590d8217f340e153d898" }
 reqwest = { version = "^0.11.22", default-features = false, features = [
     "blocking",
     "json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "Apache-2.0"
 repository = "https://github.com/dfinity/dfx-extensions"
 
 [workspace.dependencies]
-dfx-core = { git = "https://github.com/dfinity/sdk", rev = "7c5778a4b3c36806353f3f93ea04c7a76c42dea1" }
+dfx-core = { git = "https://github.com/dfinity/sdk", rev = "72cb25775dd9edec0a01b6ae3d4763485bd0a72e" }
 dfx-extensions-utils.path = "./extensions-utils"
 
 anyhow = "^1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "Apache-2.0"
 repository = "https://github.com/dfinity/dfx-extensions"
 
 [workspace.dependencies]
-dfx-core = { git = "https://github.com/dfinity/sdk", rev = "72cb25775dd9edec0a01b6ae3d4763485bd0a72e" }
+dfx-core = "0.1.1"
 dfx-extensions-utils.path = "./extensions-utils"
 
 anyhow = "^1"
@@ -21,8 +21,8 @@ flate2 = { version = "1.0.25", default-features = false, features = [
 ] }
 fn-error-context = "0.2.1"
 futures-util = "0.3.28"
-ic-agent = { git = "https://github.com/dfinity/agent-rs", rev = "729398880545a1f49a4c6286d0dd0c94254b236f" }
-ic-utils = { git = "https://github.com/dfinity/agent-rs", rev = "729398880545a1f49a4c6286d0dd0c94254b236f" }
+ic-agent = "=0.38.0"
+ic-utils = "=0.38.0"
 reqwest = { version = "^0.11.22", default-features = false, features = [
     "blocking",
     "json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "Apache-2.0"
 repository = "https://github.com/dfinity/dfx-extensions"
 
 [workspace.dependencies]
-dfx-core = { git = "https://github.com/dfinity/sdk", rev = "10391754ccd8d5eb92890f896369bd7c8b62af56" }
+dfx-core = { git = "https://github.com/dfinity/sdk", rev = "7c5778a4b3c36806353f3f93ea04c7a76c42dea1" }
 dfx-extensions-utils.path = "./extensions-utils"
 
 anyhow = "^1"
@@ -21,8 +21,8 @@ flate2 = { version = "1.0.25", default-features = false, features = [
 ] }
 fn-error-context = "0.2.1"
 futures-util = "0.3.28"
-ic-agent = "0.38" # { git = "https://github.com/dfinity/agent-rs", rev = "6e11a350112f9b907c4d590d8217f340e153d898" }
-ic-utils = "0.38" # { git = "https://github.com/dfinity/agent-rs", rev = "6e11a350112f9b907c4d590d8217f340e153d898" }
+ic-agent = { git = "https://github.com/dfinity/agent-rs", rev = "4642e30ab6cf148ad94bda0c12f1b9330377de36" }
+ic-utils = { git = "https://github.com/dfinity/agent-rs", rev = "4642e30ab6cf148ad94bda0c12f1b9330377de36" }
 reqwest = { version = "^0.11.22", default-features = false, features = [
     "blocking",
     "json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,8 +21,8 @@ flate2 = { version = "1.0.25", default-features = false, features = [
 ] }
 fn-error-context = "0.2.1"
 futures-util = "0.3.28"
-ic-agent = { git = "https://github.com/dfinity/agent-rs", rev = "4642e30ab6cf148ad94bda0c12f1b9330377de36" }
-ic-utils = { git = "https://github.com/dfinity/agent-rs", rev = "4642e30ab6cf148ad94bda0c12f1b9330377de36" }
+ic-agent = { git = "https://github.com/dfinity/agent-rs", rev = "729398880545a1f49a4c6286d0dd0c94254b236f" }
+ic-utils = { git = "https://github.com/dfinity/agent-rs", rev = "729398880545a1f49a4c6286d0dd0c94254b236f" }
 reqwest = { version = "^0.11.22", default-features = false, features = [
     "blocking",
     "json",

--- a/extensions/nns/CHANGELOG.md
+++ b/extensions/nns/CHANGELOG.md
@@ -1,6 +1,7 @@
 <!-- next-header -->
 
 ## [Unreleased] - ReleaseDate
+- Fixed a bug where `dfx nns install` and `dfx nns import` would fail if a canister type in dfx.json was defined by an extension.
 
 ## [0.4.6] - 2024-10-10
 - Unchanged from 0.4.5

--- a/extensions/nns/e2e/tests/nns.bash
+++ b/extensions/nns/e2e/tests/nns.bash
@@ -178,5 +178,44 @@ assert_nns_canister_id_matches() {
 @test "dfx nns install with a canister type defined by another extension" {
     install_shared_asset subnet_type/shared_network_settings/system
     dfx_start_for_nns_install
+
+    CACHE_DIR=$(dfx cache show)
+    mkdir -p "$CACHE_DIR"/extensions/embera
+    cat > "$CACHE_DIR"/extensions/embera/extension.json <<EOF
+    {
+      "name": "embera",
+      "version": "0.1.0",
+      "homepage": "https://github.com/dfinity/dfx-extensions",
+      "authors": "DFINITY",
+      "summary": "Test extension for e2e purposes.",
+      "categories": [],
+      "keywords": [],
+      "canister_type": {
+       "evaluation_order": [ "wasm" ],
+       "defaults": {
+         "type": "custom",
+         "build": [
+           "echo the embera build step for canister {{canister_name}} with candid {{canister.candid}} and main file {{canister.main}} and gzip is {{canister.gzip}}",
+           "mkdir -p .embera/{{canister_name}}",
+           "cp main.wasm {{canister.wasm}}"
+         ],
+         "gzip": true,
+         "wasm": ".embera/{{canister_name}}/{{canister_name}}.wasm"
+       }
+      }
+    }
+EOF
+    cat > dfx.json <<EOF
+    {
+      "canisters": {
+        "c1": {
+          "type": "embera",
+          "candid": "main.did",
+          "main": "main-file.embera"
+        }
+      }
+    }
+EOF
+
     dfx nns install
 }

--- a/extensions/nns/e2e/tests/nns.bash
+++ b/extensions/nns/e2e/tests/nns.bash
@@ -191,15 +191,8 @@ assert_nns_canister_id_matches() {
       "categories": [],
       "keywords": [],
       "canister_type": {
-       "evaluation_order": [ "wasm" ],
        "defaults": {
          "type": "custom",
-         "build": [
-           "echo the embera build step for canister {{canister_name}} with candid {{canister.candid}} and main file {{canister.main}} and gzip is {{canister.gzip}}",
-           "mkdir -p .embera/{{canister_name}}",
-           "cp main.wasm {{canister.wasm}}"
-         ],
-         "gzip": true,
          "wasm": ".embera/{{canister_name}}/{{canister_name}}.wasm"
        }
       }

--- a/extensions/nns/e2e/tests/nns.bash
+++ b/extensions/nns/e2e/tests/nns.bash
@@ -175,3 +175,8 @@ assert_nns_canister_id_matches() {
     fi
 }
 
+@test "dfx nns install with a canister type defined by another extension" {
+    install_shared_asset subnet_type/shared_network_settings/system
+    dfx_start_for_nns_install
+    dfx nns install
+}

--- a/extensions/nns/src/commands/import.rs
+++ b/extensions/nns/src/commands/import.rs
@@ -1,10 +1,8 @@
 //! Code for the command line: `dfx nns import`
 use std::{collections::BTreeMap, path::Path};
 
-use dfx_core::config::cache::get_version_from_cache_path;
 use dfx_core::config::model::canister_id_store::CanisterIds;
 use dfx_core::config::model::dfinity::Config;
-use dfx_core::extension::manager::ExtensionManager;
 use dfx_extensions_utils::{
     get_canisters_json_object, get_network_mappings, import_canister_definitions, new_logger,
     replica_rev, set_remote_canister_ids, ImportNetworkMapping, NNS_CORE,
@@ -28,9 +26,7 @@ pub struct ImportOpts {
 
 /// Executes `dfx nns import`
 pub async fn exec(opts: ImportOpts, dfx_cache_path: &Path) -> anyhow::Result<()> {
-    let version = get_version_from_cache_path(dfx_cache_path)?;
-    let extension_manager = ExtensionManager::new(&version)?;
-    let config = Config::from_current_dir(Some(&extension_manager))?;
+    let config = Config::from_current_dir(None)?;
     if config.is_none() {
         anyhow::bail!(crate::errors::DFXJSON_NOT_FOUND);
     }

--- a/extensions/nns/src/commands/import.rs
+++ b/extensions/nns/src/commands/import.rs
@@ -1,8 +1,10 @@
 //! Code for the command line: `dfx nns import`
 use std::{collections::BTreeMap, path::Path};
 
+use dfx_core::config::cache::get_version_from_cache_path;
 use dfx_core::config::model::canister_id_store::CanisterIds;
 use dfx_core::config::model::dfinity::Config;
+use dfx_core::extension::manager::ExtensionManager;
 use dfx_extensions_utils::{
     get_canisters_json_object, get_network_mappings, import_canister_definitions, new_logger,
     replica_rev, set_remote_canister_ids, ImportNetworkMapping, NNS_CORE,
@@ -26,7 +28,9 @@ pub struct ImportOpts {
 
 /// Executes `dfx nns import`
 pub async fn exec(opts: ImportOpts, dfx_cache_path: &Path) -> anyhow::Result<()> {
-    let config = Config::from_current_dir(None)?;
+    let version = get_version_from_cache_path(dfx_cache_path)?;
+    let extension_manager = ExtensionManager::new(&version)?;
+    let config = Config::from_current_dir(Some(&extension_manager))?;
     if config.is_none() {
         anyhow::bail!(crate::errors::DFXJSON_NOT_FOUND);
     }

--- a/extensions/nns/src/commands/install.rs
+++ b/extensions/nns/src/commands/install.rs
@@ -1,7 +1,7 @@
 //! Code for the command line: `dfx nns install`
 use crate::install_nns::{get_and_check_replica_url, get_with_retries, install_nns};
 use clap::Parser;
-use dfx_core::DfxInterfaceBuilder;
+use dfx_core::DfxInterface;
 use dfx_extensions_utils::new_logger;
 use std::path::Path;
 
@@ -28,11 +28,7 @@ pub struct InstallOpts {
 
 /// Executes `dfx nns install`.
 pub async fn exec(opts: InstallOpts, dfx_cache_path: &Path) -> anyhow::Result<()> {
-    let dfx = DfxInterfaceBuilder::new()
-        .anonymous()
-        .with_extension_manager_from_cache_path(dfx_cache_path)?
-        .build()
-        .await?;
+    let dfx = DfxInterface::anonymous().await?;
     let mut network_descriptor = dfx.network_descriptor().clone();
     if let Some(ref mut local_server_descriptor) = &mut network_descriptor.local_server_descriptor {
         local_server_descriptor.load_settings_digest()?;

--- a/extensions/nns/src/commands/install.rs
+++ b/extensions/nns/src/commands/install.rs
@@ -1,7 +1,7 @@
 //! Code for the command line: `dfx nns install`
 use crate::install_nns::{get_and_check_replica_url, get_with_retries, install_nns};
 use clap::Parser;
-use dfx_core::DfxInterface;
+use dfx_core::DfxInterfaceBuilder;
 use dfx_extensions_utils::new_logger;
 use std::path::Path;
 
@@ -28,7 +28,11 @@ pub struct InstallOpts {
 
 /// Executes `dfx nns install`.
 pub async fn exec(opts: InstallOpts, dfx_cache_path: &Path) -> anyhow::Result<()> {
-    let dfx = DfxInterface::anonymous().await?;
+    let dfx = DfxInterfaceBuilder::new()
+        .anonymous()
+        .with_extension_manager_from_cache_path(dfx_cache_path)?
+        .build()
+        .await?;
     let mut network_descriptor = dfx.network_descriptor().clone();
     if let Some(ref mut local_server_descriptor) = &mut network_descriptor.local_server_descriptor {
         local_server_descriptor.load_settings_digest()?;

--- a/extensions/sns/CHANGELOG.md
+++ b/extensions/sns/CHANGELOG.md
@@ -1,6 +1,7 @@
 <!-- next-header -->
 
 ## [Unreleased] - ReleaseDate
+- Fixed a bug where `dfx sns import` would fail if a canister type in dfx.json was defined by an extension.
 
 ## [0.4.6] - 2024-10-11
 - Added `dfx sns health` command.

--- a/extensions/sns/src/commands/import.rs
+++ b/extensions/sns/src/commands/import.rs
@@ -7,6 +7,8 @@ use dfx_extensions_utils::{
 };
 
 use clap::Parser;
+use dfx_core::config::cache::get_version_from_cache_path;
+use dfx_core::extension::manager::ExtensionManager;
 
 /// Imports the sns canisters
 #[derive(Parser)]
@@ -23,7 +25,9 @@ pub struct SnsImportOpts {
 
 /// Executes the command line `dfx sns import`.
 pub async fn exec(opts: SnsImportOpts, dfx_cache_path: &Path) -> anyhow::Result<()> {
-    let config = Config::from_current_dir(None)?;
+    let version = get_version_from_cache_path(dfx_cache_path)?;
+    let extension_manager = ExtensionManager::new(&version)?;
+    let config = Config::from_current_dir(Some(&extension_manager))?;
     if config.is_none() {
         anyhow::bail!(crate::errors::DFXJSON_NOT_FOUND);
     }


### PR DESCRIPTION
`dfx nns install`, `dfx nns import`, and `dfx sns import` all load dfx.json if present.  If dfx.json includes a canister with a type defined by an extension, the config loader won't recognize the type unless we provide an ExtensionManager.  This PR provides the needed ExtensionManager.

Fixes https://dfinity.atlassian.net/browse/SDK-1832