### PR TITLE
feat(sns): Add `health` command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,11 +4,11 @@ version = 3
 
 [[package]]
 name = "addr2line"
-version = "0.24.1"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5fb1d8e4442bd405fdfd1dacb42792696b0cf9cb15882e5d097b742a676d375"
+checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
 dependencies = [
- "gimli 0.31.0",
+ "gimli 0.31.1",
 ]
 
 [[package]]
@@ -174,9 +174,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.88"
+version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e1496f8fb1fbf272686b8d37f523dab3e4a7443300055e74cdaa449f3114356"
+checksum = "86fdf8605db99b54d3cd748a44c6d04df638eb5dafb219b135d0149bd0db01f6"
 
 [[package]]
 name = "arc-swap"
@@ -249,13 +249,13 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.82"
+version = "0.1.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a27b8a3a6e1a44fa4c8baf1f653e4172e81486d4941f2237e20dc2d0cf4ddff1"
+checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -277,9 +277,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
+checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "backoff"
@@ -489,7 +489,7 @@ dependencies = [
  "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
  "syn_derive",
 ]
 
@@ -613,9 +613,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.7.1"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8318a53db07bb3f8dca91a600466bdb3f2eaadeedfdbcf02e1accbad9271ba50"
+checksum = "428d9aa8fbc0670b7b8d6030a7fadd0f86151cae55e4dbbece15f3780a3dfaf3"
 
 [[package]]
 name = "cached"
@@ -671,7 +671,7 @@ dependencies = [
  "lazy_static",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -698,9 +698,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.1.18"
+version = "1.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b62ac837cdb5cb22e10a256099b4fc502b1dfe560cb282963a974d7abd80e476"
+checksum = "2e80e3b6a3ab07840e1cae9b0666a63970dc28e8ed5ffbcdacbfc760c281bfc1"
 dependencies = [
  "jobserver",
  "libc",
@@ -797,19 +797,19 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.17"
+version = "4.5.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e5a21b8495e732f1b3c364c9949b201ca7bae518c502c80256c96ad79eaf6ac"
+checksum = "b97f376d85a664d5837dbae44bf546e6477a679ff6610010f17276f686d867e8"
 dependencies = [
  "clap_builder",
- "clap_derive 4.5.13",
+ "clap_derive 4.5.18",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.17"
+version = "4.5.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cf2dd12af7a047ad9d6da2b6b249759a22a7abc0f474c1dae1777afa4b21a73"
+checksum = "19bc80abd44e4bed93ca373a0704ccbd1b710dc5749406201bb018272808dc54"
 dependencies = [
  "anstream",
  "anstyle",
@@ -832,14 +832,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.13"
+version = "4.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "501d359d5f3dcaf6ecdeee48833ae73ec6e42723a1e52419c79abf9507eec0a0"
+checksum = "4ac6a0c7b1a9e9a5186361f67dfa1b88213572f427fb9ab038efb2bd8c582dab"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -1095,7 +1095,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -1123,7 +1123,7 @@ dependencies = [
 [[package]]
 name = "cycles-minting-canister"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
+source = "git+https://github.com/dfinity/ic?rev=61f05b60fb3464cec774da4dc81aca0dc4fa8366#61f05b60fb3464cec774da4dc81aca0dc4fa8366"
 dependencies = [
  "async-trait",
  "base64 0.13.1",
@@ -1158,7 +1158,7 @@ dependencies = [
  "serde",
  "serde_cbor",
  "sha2 0.10.8",
- "yansi",
+ "yansi 0.5.1",
 ]
 
 [[package]]
@@ -1206,7 +1206,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.11.1",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -1228,7 +1228,7 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core 0.20.10",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -1296,13 +1296,13 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
 name = "dfn_candid"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
+source = "git+https://github.com/dfinity/ic?rev=61f05b60fb3464cec774da4dc81aca0dc4fa8366#61f05b60fb3464cec774da4dc81aca0dc4fa8366"
 dependencies = [
  "candid",
  "dfn_core",
@@ -1314,7 +1314,7 @@ dependencies = [
 [[package]]
 name = "dfn_core"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
+source = "git+https://github.com/dfinity/ic?rev=61f05b60fb3464cec774da4dc81aca0dc4fa8366#61f05b60fb3464cec774da4dc81aca0dc4fa8366"
 dependencies = [
  "ic-base-types",
  "on_wire",
@@ -1323,7 +1323,7 @@ dependencies = [
 [[package]]
 name = "dfn_http"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
+source = "git+https://github.com/dfinity/ic?rev=61f05b60fb3464cec774da4dc81aca0dc4fa8366#61f05b60fb3464cec774da4dc81aca0dc4fa8366"
 dependencies = [
  "candid",
  "dfn_candid",
@@ -1335,7 +1335,7 @@ dependencies = [
 [[package]]
 name = "dfn_http_metrics"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
+source = "git+https://github.com/dfinity/ic?rev=61f05b60fb3464cec774da4dc81aca0dc4fa8366#61f05b60fb3464cec774da4dc81aca0dc4fa8366"
 dependencies = [
  "dfn_candid",
  "dfn_core",
@@ -1348,7 +1348,7 @@ dependencies = [
 [[package]]
 name = "dfn_protobuf"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
+source = "git+https://github.com/dfinity/ic?rev=61f05b60fb3464cec774da4dc81aca0dc4fa8366#61f05b60fb3464cec774da4dc81aca0dc4fa8366"
 dependencies = [
  "on_wire",
  "prost",
@@ -1366,7 +1366,7 @@ dependencies = [
  "byte-unit",
  "bytes",
  "candid",
- "clap 4.5.17",
+ "clap 4.5.20",
  "dialoguer",
  "directories-next",
  "dunce",
@@ -1381,7 +1381,7 @@ dependencies = [
  "k256 0.11.6",
  "keyring",
  "lazy_static",
- "reqwest 0.12.7",
+ "reqwest 0.12.8",
  "ring 0.16.20",
  "schemars",
  "sec1 0.3.0",
@@ -1405,7 +1405,7 @@ dependencies = [
  "anyhow",
  "backoff",
  "candid",
- "clap 4.5.17",
+ "clap 4.5.20",
  "dfx-core",
  "flate2",
  "fn-error-context",
@@ -1784,9 +1784,9 @@ checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
-version = "1.0.33"
+version = "1.0.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "324a1be68054ef05ad64b861cc9eaf1d623d2d8cb25b4bf2cb9cdd902b4bf253"
+checksum = "a1b589b4dc103969ad3cf85c950899926ec64300a1a46d76c03a6072957036f0"
 dependencies = [
  "crc32fast",
  "libz-ng-sys",
@@ -1801,7 +1801,7 @@ checksum = "2cd66269887534af4b0c3e3337404591daa8dc8b9b2b3db71f9523beb4bafb41"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -1848,9 +1848,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1863,9 +1863,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1873,15 +1873,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1890,9 +1890,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
 name = "futures-lite"
@@ -1911,32 +1911,32 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
 
 [[package]]
 name = "futures-task"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
 
 [[package]]
 name = "futures-util"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1995,9 +1995,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.31.0"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32085ea23f3234fc7846555e85283ba4de91e21016dc0455a16286d87a292d64"
+checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "glob"
@@ -2039,7 +2039,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap 2.5.0",
+ "indexmap 2.6.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -2058,7 +2058,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.1.0",
- "indexmap 2.5.0",
+ "indexmap 2.6.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -2114,6 +2114,12 @@ dependencies = [
  "allocator-api2",
  "serde",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
 
 [[package]]
 name = "heck"
@@ -2273,9 +2279,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.9.4"
+version = "1.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fcc0b4a115bf80b728eb8ea024ad5bd707b615bfed49e0665b6e0f86fd082d9"
+checksum = "7d71d3574edd2771538b901e6549113b4006ece66150fb69c0fb6d9a2adae946"
 
 [[package]]
 name = "httpdate"
@@ -2383,13 +2389,13 @@ dependencies = [
  "http 1.1.0",
  "hyper 1.4.1",
  "hyper-util",
- "rustls 0.23.13",
+ "rustls 0.23.14",
  "rustls-native-certs 0.8.0",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.0",
  "tower-service",
- "webpki-roots 0.26.5",
+ "webpki-roots 0.26.6",
 ]
 
 [[package]]
@@ -2407,9 +2413,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da62f120a8a37763efb0cf8fdf264b884c7b8b9ac8660b900c8661030c00e6ba"
+checksum = "41296eb09f183ac68eec06e03cdbea2e759633d4067b2f6552fc2e009bcad08b"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -2420,16 +2426,15 @@ dependencies = [
  "pin-project-lite",
  "socket2 0.5.7",
  "tokio",
- "tower",
  "tower-service",
  "tracing",
 ]
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.60"
+version = "0.1.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7ffbb5a1b541ea2561f8c41c087286cc091e21e556a4f09a8f6cbf17b69b141"
+checksum = "235e081f3925a06703c2d0117ea8b91f042756fd6e7a6e5d901e8ca1a996b220"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -2471,14 +2476,14 @@ dependencies = [
  "ic-certification",
  "ic-transport-types 0.37.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ic-verify-bls-signature",
- "k256 0.13.3",
+ "k256 0.13.4",
  "leb128",
  "p256",
  "pem 3.0.4",
  "pkcs8 0.10.2",
  "rand",
  "rangemap",
- "reqwest 0.12.7",
+ "reqwest 0.12.8",
  "ring 0.17.8",
  "rustls-webpki 0.102.8",
  "sec1 0.7.3",
@@ -2512,14 +2517,14 @@ dependencies = [
  "ic-certification",
  "ic-transport-types 0.37.1 (git+https://github.com/dfinity/agent-rs?rev=6e11a350112f9b907c4d590d8217f340e153d898)",
  "ic-verify-bls-signature",
- "k256 0.13.3",
+ "k256 0.13.4",
  "leb128",
  "p256",
  "pem 3.0.4",
  "pkcs8 0.10.2",
  "rand",
  "rangemap",
- "reqwest 0.12.7",
+ "reqwest 0.12.8",
  "ring 0.17.8",
  "rustls-webpki 0.102.8",
  "sec1 0.7.3",
@@ -2538,7 +2543,7 @@ dependencies = [
 [[package]]
 name = "ic-base-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
+source = "git+https://github.com/dfinity/ic?rev=61f05b60fb3464cec774da4dc81aca0dc4fa8366#61f05b60fb3464cec774da4dc81aca0dc4fa8366"
 dependencies = [
  "byte-unit",
  "bytes",
@@ -2568,7 +2573,7 @@ dependencies = [
 [[package]]
 name = "ic-btc-replica-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
+source = "git+https://github.com/dfinity/ic?rev=61f05b60fb3464cec774da4dc81aca0dc4fa8366#61f05b60fb3464cec774da4dc81aca0dc4fa8366"
 dependencies = [
  "candid",
  "ic-btc-interface",
@@ -2581,7 +2586,7 @@ dependencies = [
 [[package]]
 name = "ic-canister-client-sender"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
+source = "git+https://github.com/dfinity/ic?rev=61f05b60fb3464cec774da4dc81aca0dc4fa8366#61f05b60fb3464cec774da4dc81aca0dc4fa8366"
 dependencies = [
  "ic-base-types",
  "ic-crypto-ed25519",
@@ -2594,7 +2599,7 @@ dependencies = [
 [[package]]
 name = "ic-canister-log"
 version = "0.2.0"
-source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
+source = "git+https://github.com/dfinity/ic?rev=61f05b60fb3464cec774da4dc81aca0dc4fa8366#61f05b60fb3464cec774da4dc81aca0dc4fa8366"
 dependencies = [
  "serde",
 ]
@@ -2602,7 +2607,7 @@ dependencies = [
 [[package]]
 name = "ic-canister-profiler"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
+source = "git+https://github.com/dfinity/ic?rev=61f05b60fb3464cec774da4dc81aca0dc4fa8366#61f05b60fb3464cec774da4dc81aca0dc4fa8366"
 dependencies = [
  "ic-metrics-encoder",
  "ic0 0.18.11",
@@ -2611,7 +2616,7 @@ dependencies = [
 [[package]]
 name = "ic-canisters-http-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
+source = "git+https://github.com/dfinity/ic?rev=61f05b60fb3464cec774da4dc81aca0dc4fa8366#61f05b60fb3464cec774da4dc81aca0dc4fa8366"
 dependencies = [
  "candid",
  "dfn_candid",
@@ -2700,7 +2705,7 @@ dependencies = [
 [[package]]
 name = "ic-config"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
+source = "git+https://github.com/dfinity/ic?rev=61f05b60fb3464cec774da4dc81aca0dc4fa8366#61f05b60fb3464cec774da4dc81aca0dc4fa8366"
 dependencies = [
  "ic-base-types",
  "ic-protobuf",
@@ -2715,7 +2720,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-ed25519"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
+source = "git+https://github.com/dfinity/ic?rev=61f05b60fb3464cec774da4dc81aca0dc4fa8366#61f05b60fb3464cec774da4dc81aca0dc4fa8366"
 dependencies = [
  "curve25519-dalek",
  "ed25519-dalek",
@@ -2729,7 +2734,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-getrandom-for-wasm"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
+source = "git+https://github.com/dfinity/ic?rev=61f05b60fb3464cec774da4dc81aca0dc4fa8366#61f05b60fb3464cec774da4dc81aca0dc4fa8366"
 dependencies = [
  "getrandom",
 ]
@@ -2737,7 +2742,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-sha2"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
+source = "git+https://github.com/dfinity/ic?rev=61f05b60fb3464cec774da4dc81aca0dc4fa8366#61f05b60fb3464cec774da4dc81aca0dc4fa8366"
 dependencies = [
  "sha2 0.10.8",
 ]
@@ -2745,7 +2750,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-internal-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
+source = "git+https://github.com/dfinity/ic?rev=61f05b60fb3464cec774da4dc81aca0dc4fa8366#61f05b60fb3464cec774da4dc81aca0dc4fa8366"
 dependencies = [
  "arrayvec 0.7.6",
  "hex",
@@ -2762,10 +2767,10 @@ dependencies = [
 [[package]]
 name = "ic-crypto-secp256k1"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
+source = "git+https://github.com/dfinity/ic?rev=61f05b60fb3464cec774da4dc81aca0dc4fa8366#61f05b60fb3464cec774da4dc81aca0dc4fa8366"
 dependencies = [
  "hmac 0.12.1",
- "k256 0.13.3",
+ "k256 0.13.4",
  "lazy_static",
  "num-bigint 0.4.6",
  "pem 1.1.1",
@@ -2778,7 +2783,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-sha2"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
+source = "git+https://github.com/dfinity/ic?rev=61f05b60fb3464cec774da4dc81aca0dc4fa8366#61f05b60fb3464cec774da4dc81aca0dc4fa8366"
 dependencies = [
  "ic-crypto-internal-sha2",
 ]
@@ -2786,7 +2791,7 @@ dependencies = [
 [[package]]
 name = "ic-crypto-tree-hash"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
+source = "git+https://github.com/dfinity/ic?rev=61f05b60fb3464cec774da4dc81aca0dc4fa8366#61f05b60fb3464cec774da4dc81aca0dc4fa8366"
 dependencies = [
  "ic-crypto-internal-types",
  "ic-crypto-sha2",
@@ -2799,7 +2804,7 @@ dependencies = [
 [[package]]
 name = "ic-error-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
+source = "git+https://github.com/dfinity/ic?rev=61f05b60fb3464cec774da4dc81aca0dc4fa8366#61f05b60fb3464cec774da4dc81aca0dc4fa8366"
 dependencies = [
  "ic-protobuf",
  "ic-utils 0.9.0",
@@ -2811,14 +2816,14 @@ dependencies = [
 [[package]]
 name = "ic-http-utils"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
+source = "git+https://github.com/dfinity/ic?rev=61f05b60fb3464cec774da4dc81aca0dc4fa8366#61f05b60fb3464cec774da4dc81aca0dc4fa8366"
 dependencies = [
  "flate2",
  "hex",
  "http 1.1.0",
  "ic-crypto-sha2",
  "ic-logger",
- "reqwest 0.12.7",
+ "reqwest 0.12.8",
  "slog",
  "tar",
  "tokio",
@@ -2828,7 +2833,7 @@ dependencies = [
 [[package]]
 name = "ic-icp-index"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
+source = "git+https://github.com/dfinity/ic?rev=61f05b60fb3464cec774da4dc81aca0dc4fa8366#61f05b60fb3464cec774da4dc81aca0dc4fa8366"
 dependencies = [
  "candid",
  "ciborium",
@@ -2856,7 +2861,7 @@ dependencies = [
 [[package]]
 name = "ic-icrc1"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
+source = "git+https://github.com/dfinity/ic?rev=61f05b60fb3464cec774da4dc81aca0dc4fa8366#61f05b60fb3464cec774da4dc81aca0dc4fa8366"
 dependencies = [
  "candid",
  "ciborium",
@@ -2879,7 +2884,7 @@ dependencies = [
 [[package]]
 name = "ic-icrc1-index-ng"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
+source = "git+https://github.com/dfinity/ic?rev=61f05b60fb3464cec774da4dc81aca0dc4fa8366#61f05b60fb3464cec774da4dc81aca0dc4fa8366"
 dependencies = [
  "candid",
  "ciborium",
@@ -2907,7 +2912,7 @@ dependencies = [
 [[package]]
 name = "ic-icrc1-ledger"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
+source = "git+https://github.com/dfinity/ic?rev=61f05b60fb3464cec774da4dc81aca0dc4fa8366#61f05b60fb3464cec774da4dc81aca0dc4fa8366"
 dependencies = [
  "async-trait",
  "candid",
@@ -2936,7 +2941,7 @@ dependencies = [
 [[package]]
 name = "ic-icrc1-tokens-u64"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
+source = "git+https://github.com/dfinity/ic?rev=61f05b60fb3464cec774da4dc81aca0dc4fa8366#61f05b60fb3464cec774da4dc81aca0dc4fa8366"
 dependencies = [
  "candid",
  "ic-ledger-core",
@@ -2961,7 +2966,7 @@ dependencies = [
 [[package]]
 name = "ic-ledger-canister-core"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
+source = "git+https://github.com/dfinity/ic?rev=61f05b60fb3464cec774da4dc81aca0dc4fa8366#61f05b60fb3464cec774da4dc81aca0dc4fa8366"
 dependencies = [
  "async-trait",
  "candid",
@@ -2979,7 +2984,7 @@ dependencies = [
 [[package]]
 name = "ic-ledger-core"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
+source = "git+https://github.com/dfinity/ic?rev=61f05b60fb3464cec774da4dc81aca0dc4fa8366#61f05b60fb3464cec774da4dc81aca0dc4fa8366"
 dependencies = [
  "candid",
  "ic-ledger-hash-of",
@@ -2991,7 +2996,7 @@ dependencies = [
 [[package]]
 name = "ic-ledger-hash-of"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
+source = "git+https://github.com/dfinity/ic?rev=61f05b60fb3464cec774da4dc81aca0dc4fa8366#61f05b60fb3464cec774da4dc81aca0dc4fa8366"
 dependencies = [
  "candid",
  "hex",
@@ -3001,12 +3006,12 @@ dependencies = [
 [[package]]
 name = "ic-limits"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
+source = "git+https://github.com/dfinity/ic?rev=61f05b60fb3464cec774da4dc81aca0dc4fa8366#61f05b60fb3464cec774da4dc81aca0dc4fa8366"
 
 [[package]]
 name = "ic-logger"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
+source = "git+https://github.com/dfinity/ic?rev=61f05b60fb3464cec774da4dc81aca0dc4fa8366#61f05b60fb3464cec774da4dc81aca0dc4fa8366"
 dependencies = [
  "chrono",
  "ic-config",
@@ -3023,7 +3028,7 @@ dependencies = [
 [[package]]
 name = "ic-management-canister-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
+source = "git+https://github.com/dfinity/ic?rev=61f05b60fb3464cec774da4dc81aca0dc4fa8366#61f05b60fb3464cec774da4dc81aca0dc4fa8366"
 dependencies = [
  "candid",
  "ic-base-types",
@@ -3049,16 +3054,21 @@ checksum = "8b5c7628eac357aecda461130f8074468be5aa4d258a002032d82d817f79f1f8"
 [[package]]
 name = "ic-nervous-system-agent"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
+source = "git+https://github.com/dfinity/ic?rev=61f05b60fb3464cec774da4dc81aca0dc4fa8366#61f05b60fb3464cec774da4dc81aca0dc4fa8366"
 dependencies = [
  "anyhow",
  "candid",
  "ic-agent 0.37.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "ic-base-types",
  "ic-nervous-system-clients",
+ "ic-nns-common",
  "ic-nns-constants",
+ "ic-nns-governance-api",
  "ic-sns-governance",
+ "ic-sns-root",
+ "ic-sns-swap",
  "ic-sns-wasm",
+ "pocket-ic",
  "serde",
  "tempfile",
  "thiserror",
@@ -3068,7 +3078,7 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-canisters"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
+source = "git+https://github.com/dfinity/ic?rev=61f05b60fb3464cec774da4dc81aca0dc4fa8366#61f05b60fb3464cec774da4dc81aca0dc4fa8366"
 dependencies = [
  "async-trait",
  "candid",
@@ -3085,7 +3095,7 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-clients"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
+source = "git+https://github.com/dfinity/ic?rev=61f05b60fb3464cec774da4dc81aca0dc4fa8366#61f05b60fb3464cec774da4dc81aca0dc4fa8366"
 dependencies = [
  "async-trait",
  "candid",
@@ -3108,12 +3118,12 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-collections-union-multi-map"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
+source = "git+https://github.com/dfinity/ic?rev=61f05b60fb3464cec774da4dc81aca0dc4fa8366#61f05b60fb3464cec774da4dc81aca0dc4fa8366"
 
 [[package]]
 name = "ic-nervous-system-common"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
+source = "git+https://github.com/dfinity/ic?rev=61f05b60fb3464cec774da4dc81aca0dc4fa8366#61f05b60fb3464cec774da4dc81aca0dc4fa8366"
 dependencies = [
  "async-trait",
  "base64 0.13.1",
@@ -3148,12 +3158,12 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-common-build-metadata"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
+source = "git+https://github.com/dfinity/ic?rev=61f05b60fb3464cec774da4dc81aca0dc4fa8366#61f05b60fb3464cec774da4dc81aca0dc4fa8366"
 
 [[package]]
 name = "ic-nervous-system-common-test-keys"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
+source = "git+https://github.com/dfinity/ic?rev=61f05b60fb3464cec774da4dc81aca0dc4fa8366#61f05b60fb3464cec774da4dc81aca0dc4fa8366"
 dependencies = [
  "ic-base-types",
  "ic-canister-client-sender",
@@ -3166,12 +3176,12 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-common-validation"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
+source = "git+https://github.com/dfinity/ic?rev=61f05b60fb3464cec774da4dc81aca0dc4fa8366#61f05b60fb3464cec774da4dc81aca0dc4fa8366"
 
 [[package]]
 name = "ic-nervous-system-governance"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
+source = "git+https://github.com/dfinity/ic?rev=61f05b60fb3464cec774da4dc81aca0dc4fa8366#61f05b60fb3464cec774da4dc81aca0dc4fa8366"
 dependencies = [
  "ic-base-types",
  "ic-stable-structures",
@@ -3183,7 +3193,7 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-humanize"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
+source = "git+https://github.com/dfinity/ic?rev=61f05b60fb3464cec774da4dc81aca0dc4fa8366#61f05b60fb3464cec774da4dc81aca0dc4fa8366"
 dependencies = [
  "humantime",
  "ic-nervous-system-proto",
@@ -3193,14 +3203,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "ic-nervous-system-initial-supply"
+version = "0.0.1"
+source = "git+https://github.com/dfinity/ic?rev=61f05b60fb3464cec774da4dc81aca0dc4fa8366#61f05b60fb3464cec774da4dc81aca0dc4fa8366"
+dependencies = [
+ "async-trait",
+ "candid",
+ "ic-base-types",
+ "ic-nervous-system-runtime",
+ "icrc-ledger-types",
+ "lazy_static",
+ "num-bigint 0.4.6",
+]
+
+[[package]]
 name = "ic-nervous-system-lock"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
+source = "git+https://github.com/dfinity/ic?rev=61f05b60fb3464cec774da4dc81aca0dc4fa8366#61f05b60fb3464cec774da4dc81aca0dc4fa8366"
 
 [[package]]
 name = "ic-nervous-system-proto"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
+source = "git+https://github.com/dfinity/ic?rev=61f05b60fb3464cec774da4dc81aca0dc4fa8366#61f05b60fb3464cec774da4dc81aca0dc4fa8366"
 dependencies = [
  "candid",
  "comparable",
@@ -3213,7 +3237,7 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-proxied-canister-calls-tracker"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
+source = "git+https://github.com/dfinity/ic?rev=61f05b60fb3464cec774da4dc81aca0dc4fa8366#61f05b60fb3464cec774da4dc81aca0dc4fa8366"
 dependencies = [
  "ic-base-types",
 ]
@@ -3221,7 +3245,7 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-root"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
+source = "git+https://github.com/dfinity/ic?rev=61f05b60fb3464cec774da4dc81aca0dc4fa8366#61f05b60fb3464cec774da4dc81aca0dc4fa8366"
 dependencies = [
  "candid",
  "dfn_core",
@@ -3237,7 +3261,7 @@ dependencies = [
 [[package]]
 name = "ic-nervous-system-runtime"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
+source = "git+https://github.com/dfinity/ic?rev=61f05b60fb3464cec774da4dc81aca0dc4fa8366#61f05b60fb3464cec774da4dc81aca0dc4fa8366"
 dependencies = [
  "async-trait",
  "candid",
@@ -3248,14 +3272,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "ic-nervous-system-string"
-version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
-
-[[package]]
 name = "ic-neurons-fund"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
+source = "git+https://github.com/dfinity/ic?rev=61f05b60fb3464cec774da4dc81aca0dc4fa8366#61f05b60fb3464cec774da4dc81aca0dc4fa8366"
 dependencies = [
  "ic-nervous-system-common",
  "lazy_static",
@@ -3268,7 +3287,7 @@ dependencies = [
 [[package]]
 name = "ic-nns-common"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
+source = "git+https://github.com/dfinity/ic?rev=61f05b60fb3464cec774da4dc81aca0dc4fa8366#61f05b60fb3464cec774da4dc81aca0dc4fa8366"
 dependencies = [
  "candid",
  "comparable",
@@ -3294,7 +3313,7 @@ dependencies = [
 [[package]]
 name = "ic-nns-constants"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
+source = "git+https://github.com/dfinity/ic?rev=61f05b60fb3464cec774da4dc81aca0dc4fa8366#61f05b60fb3464cec774da4dc81aca0dc4fa8366"
 dependencies = [
  "ic-base-types",
  "maplit",
@@ -3303,7 +3322,7 @@ dependencies = [
 [[package]]
 name = "ic-nns-governance-api"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
+source = "git+https://github.com/dfinity/ic?rev=61f05b60fb3464cec774da4dc81aca0dc4fa8366#61f05b60fb3464cec774da4dc81aca0dc4fa8366"
 dependencies = [
  "bytes",
  "candid",
@@ -3331,7 +3350,7 @@ dependencies = [
 [[package]]
 name = "ic-nns-handler-root-interface"
 version = "0.1.0"
-source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
+source = "git+https://github.com/dfinity/ic?rev=61f05b60fb3464cec774da4dc81aca0dc4fa8366#61f05b60fb3464cec774da4dc81aca0dc4fa8366"
 dependencies = [
  "async-trait",
  "candid",
@@ -3346,7 +3365,7 @@ dependencies = [
 [[package]]
 name = "ic-protobuf"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
+source = "git+https://github.com/dfinity/ic?rev=61f05b60fb3464cec774da4dc81aca0dc4fa8366#61f05b60fb3464cec774da4dc81aca0dc4fa8366"
 dependencies = [
  "bincode",
  "candid",
@@ -3360,7 +3379,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-keys"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
+source = "git+https://github.com/dfinity/ic?rev=61f05b60fb3464cec774da4dc81aca0dc4fa8366#61f05b60fb3464cec774da4dc81aca0dc4fa8366"
 dependencies = [
  "candid",
  "ic-base-types",
@@ -3372,7 +3391,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-subnet-type"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
+source = "git+https://github.com/dfinity/ic?rev=61f05b60fb3464cec774da4dc81aca0dc4fa8366#61f05b60fb3464cec774da4dc81aca0dc4fa8366"
 dependencies = [
  "candid",
  "ic-protobuf",
@@ -3384,7 +3403,7 @@ dependencies = [
 [[package]]
 name = "ic-registry-transport"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
+source = "git+https://github.com/dfinity/ic?rev=61f05b60fb3464cec774da4dc81aca0dc4fa8366#61f05b60fb3464cec774da4dc81aca0dc4fa8366"
 dependencies = [
  "candid",
  "ic-base-types",
@@ -3396,12 +3415,12 @@ dependencies = [
 [[package]]
 name = "ic-sns-cli"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
+source = "git+https://github.com/dfinity/ic?rev=61f05b60fb3464cec774da4dc81aca0dc4fa8366#61f05b60fb3464cec774da4dc81aca0dc4fa8366"
 dependencies = [
  "anyhow",
  "base64 0.13.1",
  "candid",
- "clap 4.5.17",
+ "clap 4.5.20",
  "futures",
  "hex",
  "ic-agent 0.37.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -3433,7 +3452,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-governance"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
+source = "git+https://github.com/dfinity/ic?rev=61f05b60fb3464cec774da4dc81aca0dc4fa8366#61f05b60fb3464cec774da4dc81aca0dc4fa8366"
 dependencies = [
  "async-trait",
  "base64 0.13.1",
@@ -3492,7 +3511,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-governance-proposal-criticality"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
+source = "git+https://github.com/dfinity/ic?rev=61f05b60fb3464cec774da4dc81aca0dc4fa8366#61f05b60fb3464cec774da4dc81aca0dc4fa8366"
 dependencies = [
  "ic-nervous-system-proto",
 ]
@@ -3500,7 +3519,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-governance-proposals-amount-total-limit"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
+source = "git+https://github.com/dfinity/ic?rev=61f05b60fb3464cec774da4dc81aca0dc4fa8366#61f05b60fb3464cec774da4dc81aca0dc4fa8366"
 dependencies = [
  "ic-sns-governance-token-valuation",
  "num-traits",
@@ -3511,7 +3530,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-governance-token-valuation"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
+source = "git+https://github.com/dfinity/ic?rev=61f05b60fb3464cec774da4dc81aca0dc4fa8366#61f05b60fb3464cec774da4dc81aca0dc4fa8366"
 dependencies = [
  "async-trait",
  "candid",
@@ -3520,19 +3539,20 @@ dependencies = [
  "ic-base-types",
  "ic-cdk",
  "ic-nervous-system-common",
+ "ic-nervous-system-initial-supply",
  "ic-nervous-system-runtime",
- "ic-nervous-system-string",
  "ic-nns-constants",
  "ic-sns-swap-proto-library",
  "icrc-ledger-types",
  "mockall",
+ "num-traits",
  "rust_decimal",
 ]
 
 [[package]]
 name = "ic-sns-init"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
+source = "git+https://github.com/dfinity/ic?rev=61f05b60fb3464cec774da4dc81aca0dc4fa8366#61f05b60fb3464cec774da4dc81aca0dc4fa8366"
 dependencies = [
  "base64 0.13.1",
  "candid",
@@ -3560,7 +3580,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-root"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
+source = "git+https://github.com/dfinity/ic?rev=61f05b60fb3464cec774da4dc81aca0dc4fa8366#61f05b60fb3464cec774da4dc81aca0dc4fa8366"
 dependencies = [
  "async-trait",
  "build-info",
@@ -3581,7 +3601,6 @@ dependencies = [
  "ic-nervous-system-common-build-metadata",
  "ic-nervous-system-root",
  "ic-nervous-system-runtime",
- "ic-nns-constants",
  "ic-sns-swap",
  "icrc-ledger-types",
  "prost",
@@ -3591,7 +3610,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-swap"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
+source = "git+https://github.com/dfinity/ic?rev=61f05b60fb3464cec774da4dc81aca0dc4fa8366#61f05b60fb3464cec774da4dc81aca0dc4fa8366"
 dependencies = [
  "async-trait",
  "build-info",
@@ -3630,7 +3649,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-swap-proto-library"
 version = "0.0.1"
-source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
+source = "git+https://github.com/dfinity/ic?rev=61f05b60fb3464cec774da4dc81aca0dc4fa8366#61f05b60fb3464cec774da4dc81aca0dc4fa8366"
 dependencies = [
  "candid",
  "comparable",
@@ -3645,7 +3664,7 @@ dependencies = [
 [[package]]
 name = "ic-sns-wasm"
 version = "1.0.0"
-source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
+source = "git+https://github.com/dfinity/ic?rev=61f05b60fb3464cec774da4dc81aca0dc4fa8366#61f05b60fb3464cec774da4dc81aca0dc4fa8366"
 dependencies = [
  "async-trait",
  "candid",
@@ -3691,7 +3710,7 @@ dependencies = [
 [[package]]
 name = "ic-sys"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
+source = "git+https://github.com/dfinity/ic?rev=61f05b60fb3464cec774da4dc81aca0dc4fa8366#61f05b60fb3464cec774da4dc81aca0dc4fa8366"
 dependencies = [
  "cvt",
  "hex",
@@ -3743,7 +3762,7 @@ dependencies = [
 [[package]]
 name = "ic-types"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
+source = "git+https://github.com/dfinity/ic?rev=61f05b60fb3464cec774da4dc81aca0dc4fa8366#61f05b60fb3464cec774da4dc81aca0dc4fa8366"
 dependencies = [
  "base64 0.13.1",
  "bincode",
@@ -3780,7 +3799,7 @@ dependencies = [
 [[package]]
 name = "ic-utils"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
+source = "git+https://github.com/dfinity/ic?rev=61f05b60fb3464cec774da4dc81aca0dc4fa8366#61f05b60fb3464cec774da4dc81aca0dc4fa8366"
 dependencies = [
  "hex",
  "scoped_threadpool",
@@ -3812,7 +3831,7 @@ dependencies = [
 [[package]]
 name = "ic-validate-eq"
 version = "0.0.0"
-source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
+source = "git+https://github.com/dfinity/ic?rev=61f05b60fb3464cec774da4dc81aca0dc4fa8366#61f05b60fb3464cec774da4dc81aca0dc4fa8366"
 dependencies = [
  "ic-validate-eq-derive",
 ]
@@ -3820,7 +3839,7 @@ dependencies = [
 [[package]]
 name = "ic-validate-eq-derive"
 version = "0.0.0"
-source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
+source = "git+https://github.com/dfinity/ic?rev=61f05b60fb3464cec774da4dc81aca0dc4fa8366#61f05b60fb3464cec774da4dc81aca0dc4fa8366"
 dependencies = [
  "darling 0.20.10",
  "proc-macro2",
@@ -3844,13 +3863,13 @@ dependencies = [
 
 [[package]]
 name = "ic-wasm"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5574bf249d201ddd2c27c3fdf178ddacb1be1c705c8a5b4c1339c393758f2bf2"
+checksum = "19fabaeecfe37f24b433c62489242fc54503d98d4cc8d0f9ef7544dfdfc0ddcb"
 dependencies = [
  "anyhow",
  "candid",
- "clap 4.5.17",
+ "clap 4.5.20",
  "libflate",
  "rustc-demangle",
  "serde",
@@ -3911,7 +3930,7 @@ dependencies = [
 [[package]]
 name = "icp-ledger"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
+source = "git+https://github.com/dfinity/ic?rev=61f05b60fb3464cec774da4dc81aca0dc4fa8366#61f05b60fb3464cec774da4dc81aca0dc4fa8366"
 dependencies = [
  "candid",
  "comparable",
@@ -3941,7 +3960,7 @@ dependencies = [
 [[package]]
 name = "icrc-ledger-client"
 version = "0.1.2"
-source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
+source = "git+https://github.com/dfinity/ic?rev=61f05b60fb3464cec774da4dc81aca0dc4fa8366#61f05b60fb3464cec774da4dc81aca0dc4fa8366"
 dependencies = [
  "async-trait",
  "candid",
@@ -3952,7 +3971,7 @@ dependencies = [
 [[package]]
 name = "icrc-ledger-types"
 version = "0.1.6"
-source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
+source = "git+https://github.com/dfinity/ic?rev=61f05b60fb3464cec774da4dc81aca0dc4fa8366#61f05b60fb3464cec774da4dc81aca0dc4fa8366"
 dependencies = [
  "base32",
  "candid",
@@ -3965,6 +3984,7 @@ dependencies = [
  "serde_bytes",
  "sha2 0.10.8",
  "strum",
+ "strum_macros",
  "time",
 ]
 
@@ -4002,12 +4022,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68b900aa2f7301e21c36462b170ee99994de34dff39a4a6a528e80e7376d07e5"
+checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.5",
+ "hashbrown 0.15.0",
  "serde",
 ]
 
@@ -4042,9 +4062,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.10.0"
+version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "187674a687eed5fe42285b40c6291f9a01517d415fad1c3cbc6a9f778af7fcd4"
+checksum = "ddc24109865250148c2e0f3d25d4f0f479571723792d3802153c60922a4fb708"
 
 [[package]]
 name = "is-terminal"
@@ -4087,6 +4107,15 @@ name = "itertools"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -4152,9 +4181,9 @@ dependencies = [
 
 [[package]]
 name = "k256"
-version = "0.13.3"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "956ff9b67e26e1a6a866cb758f12c6f8746208489e3e4a4b5580802f2f0a587b"
+checksum = "f6e3919bbaa2945715f0bb6d3934a173d1e9a59ac23767fbaaef277265a7411b"
 dependencies = [
  "cfg-if",
  "ecdsa 0.16.9",
@@ -4199,9 +4228,9 @@ checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
 name = "libc"
-version = "0.2.158"
+version = "0.2.159"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
+checksum = "561d97a539a36e26a9a5fad1ea11a3039a67714694aaa379433e580854bc3dc5"
 
 [[package]]
 name = "libflate"
@@ -4310,6 +4339,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata 0.1.10",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4396,7 +4434,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -4464,7 +4502,7 @@ dependencies = [
  "anyhow",
  "backoff",
  "candid",
- "clap 4.5.17",
+ "clap 4.5.20",
  "crc32fast",
  "dfx-core",
  "dfx-extensions-utils",
@@ -4485,6 +4523,16 @@ dependencies = [
  "slog",
  "tempfile",
  "tokio",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
 ]
 
 [[package]]
@@ -4581,9 +4629,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.36.4"
+version = "0.36.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "084f1a5821ac4c651660a94a7153d27ac9d8a53736203f58b31945ded098070a"
+checksum = "aedf0a2d09c573ed1d8d85b30c119153926a2b36dce0ab28322c09a117a4683e"
 dependencies = [
  "memchr",
 ]
@@ -4591,13 +4639,13 @@ dependencies = [
 [[package]]
 name = "on_wire"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
+source = "git+https://github.com/dfinity/ic?rev=61f05b60fb3464cec774da4dc81aca0dc4fa8366#61f05b60fb3464cec774da4dc81aca0dc4fa8366"
 
 [[package]]
 name = "once_cell"
-version = "1.19.0"
+version = "1.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
 
 [[package]]
 name = "opaque-debug"
@@ -4628,7 +4676,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -4664,6 +4712,12 @@ name = "os_str_bytes"
 version = "6.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2355d85b9a3786f481747ced0e0ff2ba35213a1f9bd406ed906554d7af805a1"
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "p256"
@@ -4786,9 +4840,9 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pest"
-version = "2.7.12"
+version = "2.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c73c26c01b8c87956cea613c907c9d6ecffd8d18a2a5908e5de0adfaa185cea"
+checksum = "fdbef9d1d47087a895abd220ed25eb4ad973a5e26f6a4367b038c25e28dfc2d9"
 dependencies = [
  "memchr",
  "thiserror",
@@ -4797,9 +4851,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.7.12"
+version = "2.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "664d22978e2815783adbdd2c588b455b1bd625299ce36b2a99881ac9627e6d8d"
+checksum = "4d3a6e3394ec80feb3b6393c725571754c6188490265c61aaf260810d6b95aa0"
 dependencies = [
  "pest",
  "pest_generator",
@@ -4807,22 +4861,22 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.7.12"
+version = "2.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2d5487022d5d33f4c30d91c22afa240ce2a644e87fe08caad974d4eab6badbe"
+checksum = "94429506bde1ca69d1b5601962c73f4172ab4726571a59ea95931218cb0e930e"
 dependencies = [
  "pest",
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
 name = "pest_meta"
-version = "2.7.12"
+version = "2.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0091754bbd0ea592c4deb3a122ce8ecbb0753b738aa82bc055fcc2eccc8d8174"
+checksum = "ac8a071862e93690b6e34e9a5fb8e33ff3734473ac0245b27232222c4906a33f"
 dependencies = [
  "once_cell",
  "pest",
@@ -4836,38 +4890,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset",
- "indexmap 2.5.0",
+ "indexmap 2.6.0",
 ]
 
 [[package]]
 name = "phantom_newtype"
 version = "0.9.0"
-source = "git+https://github.com/dfinity/ic?rev=f7e561c00a2745f946372f5166fd7968fa664f53#f7e561c00a2745f946372f5166fd7968fa664f53"
+source = "git+https://github.com/dfinity/ic?rev=61f05b60fb3464cec774da4dc81aca0dc4fa8366#61f05b60fb3464cec774da4dc81aca0dc4fa8366"
 dependencies = [
  "candid",
  "num-traits",
  "serde",
  "slog",
-]
-
-[[package]]
-name = "pin-project"
-version = "1.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6bf43b791c5b9e34c3d182969b4abb522f9343702850a2e57f460d00d09b4b3"
-dependencies = [
- "pin-project-internal",
-]
-
-[[package]]
-name = "pin-project-internal"
-version = "1.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.77",
 ]
 
 [[package]]
@@ -4914,9 +4948,34 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
+checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
+
+[[package]]
+name = "pocket-ic"
+version = "5.0.0"
+source = "git+https://github.com/dfinity/ic?rev=61f05b60fb3464cec774da4dc81aca0dc4fa8366#61f05b60fb3464cec774da4dc81aca0dc4fa8366"
+dependencies = [
+ "base64 0.13.1",
+ "candid",
+ "hex",
+ "ic-agent 0.37.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ic-cdk",
+ "ic-transport-types 0.37.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "reqwest 0.12.8",
+ "schemars",
+ "serde",
+ "serde_bytes",
+ "serde_cbor",
+ "serde_json",
+ "sha2 0.10.8",
+ "slog",
+ "tokio",
+ "tracing",
+ "tracing-appender",
+ "tracing-subscriber",
+]
 
 [[package]]
 name = "polling"
@@ -5000,12 +5059,12 @@ dependencies = [
 
 [[package]]
 name = "pretty_assertions"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af7cee1a6c8a5b9208b3cb1061f10c0cb689087b3d8ce85fb9d2dd7a29b6ba66"
+checksum = "3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d"
 dependencies = [
  "diff",
- "yansi",
+ "yansi 1.0.1",
 ]
 
 [[package]]
@@ -5015,7 +5074,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479cf940fbbb3426c32c5d5176f62ad57549a0bb84773423ba8be9d089f5faba"
 dependencies = [
  "proc-macro2",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -5062,7 +5121,7 @@ version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecf48c7ca261d60b74ab1a7b20da18bede46776b2e55535cb958eb595c5fa7b"
 dependencies = [
- "toml_edit 0.22.20",
+ "toml_edit 0.22.22",
 ]
 
 [[package]]
@@ -5097,18 +5156,18 @@ checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.86"
+version = "1.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
+checksum = "b3e4daa0dcf6feba26f985457cdf104d4b4256fc5a09547140f3631bb076b19a"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "prost"
-version = "0.12.6"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deb1435c188b76130da55f17a466d252ff7b1418b2ad3e037d127b94e3411f29"
+checksum = "7b0487d90e047de87f984913713b85c601c05609aad5b0df4b4573fbf69aa13f"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -5116,13 +5175,13 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.12.6"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22505a5c94da8e3b7c2996394d1c933236c4d743e81a410bcca4e6989fc066a4"
+checksum = "0c1318b19085f08681016926435853bbf7858f9c082d0999b80550ff5d9abe15"
 dependencies = [
  "bytes",
  "heck 0.5.0",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "log",
  "multimap",
  "once_cell",
@@ -5131,28 +5190,28 @@ dependencies = [
  "prost",
  "prost-types",
  "regex",
- "syn 2.0.77",
+ "syn 2.0.79",
  "tempfile",
 ]
 
 [[package]]
 name = "prost-derive"
-version = "0.12.6"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
+checksum = "e9552f850d5f0964a4e4d0bf306459ac29323ddfbae05e35a7c0d35cb0803cc5"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
 name = "prost-types"
-version = "0.12.6"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9091c90b0a32608e984ff2fa4091273cbdd755d54935c51d520887f4a1dbd5b0"
+checksum = "4759aa0d3a6232fb8dbdb97b61de2c20047c68aca932c7ed76da9d788508d670"
 dependencies = [
  "prost",
 ]
@@ -5197,7 +5256,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash 2.0.0",
- "rustls 0.23.13",
+ "rustls 0.23.14",
  "socket2 0.5.7",
  "thiserror",
  "tokio",
@@ -5214,7 +5273,7 @@ dependencies = [
  "rand",
  "ring 0.17.8",
  "rustc-hash 2.0.0",
- "rustls 0.23.13",
+ "rustls 0.23.14",
  "slab",
  "thiserror",
  "tinyvec",
@@ -5287,9 +5346,9 @@ checksum = "f60fcc7d6849342eff22c4350c8b9a989ee8ceabc4b481253e8946b9fe83d684"
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.4"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0884ad60e090bf1345b93da0a5de8923c93884cd03f40dfcfddd3b4bee661853"
+checksum = "9b6dfecf2c74bce2466cabf93f6664d6998a69eb21e39f4207930065b27b771f"
 dependencies = [
  "bitflags 2.6.0",
 ]
@@ -5307,32 +5366,47 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.6"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619"
+checksum = "38200e5ee88914975b69f657f0801b6f6dccafd44fd9326302a4aaeecfacb1d8"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata",
- "regex-syntax",
+ "regex-automata 0.4.8",
+ "regex-syntax 0.8.5",
 ]
 
 [[package]]
 name = "regex-automata"
-version = "0.4.7"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax 0.6.29",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368758f23274712b504848e9d5a6f010445cc8b87a7cdb4d7cbee666c1288da3"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.8.5",
 ]
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.4"
+version = "0.6.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "rend"
@@ -5389,9 +5463,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.12.7"
+version = "0.12.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8f4955649ef5c38cc7f9e8aa41761d48fb9677197daea9984dc54f56aad5e63"
+checksum = "f713147fbe92361e52392c73b8c9e48c04c6625bce969ef54dc901e58e042a7b"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -5414,9 +5488,9 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.13",
- "rustls-native-certs 0.7.3",
- "rustls-pemfile 2.1.3",
+ "rustls 0.23.14",
+ "rustls-native-certs 0.8.0",
+ "rustls-pemfile 2.2.0",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -5432,7 +5506,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots 0.26.5",
+ "webpki-roots 0.26.6",
  "windows-registry",
 ]
 
@@ -5637,9 +5711,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.13"
+version = "0.23.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2dabaac7466917e566adb06783a81ca48944c6898a1b08b9374106dd671f4c8"
+checksum = "415d9944693cb90382053259f89fbb077ea730ad7273047ec63b19bc9b160ba8"
 dependencies = [
  "once_cell",
  "ring 0.17.8",
@@ -5663,25 +5737,12 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
-dependencies = [
- "openssl-probe",
- "rustls-pemfile 2.1.3",
- "rustls-pki-types",
- "schannel",
- "security-framework",
-]
-
-[[package]]
-name = "rustls-native-certs"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcaf18a4f2be7326cd874a5fa579fae794320a0f388d365dca7e480e55f83f8a"
 dependencies = [
  "openssl-probe",
- "rustls-pemfile 2.1.3",
+ "rustls-pemfile 2.2.0",
  "rustls-pki-types",
  "schannel",
  "security-framework",
@@ -5698,19 +5759,18 @@ dependencies = [
 
 [[package]]
 name = "rustls-pemfile"
-version = "2.1.3"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "196fe16b00e106300d3e45ecfcb764fa292a535d7326a29a5875c579c7417425"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
 dependencies = [
- "base64 0.22.1",
  "rustls-pki-types",
 ]
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0a2ce646f8655401bb81e7927b812614bd5d91dbc968696be50603510fcaf0"
+checksum = "0e696e35370c65c9c541198af4543ccd580cf17fc25d8e05c5a242b202488c55"
 
 [[package]]
 name = "rustls-webpki"
@@ -5747,9 +5807,9 @@ checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
 name = "schannel"
-version = "0.1.24"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9aaafd5a2b6e3d657ff009d82fbd630b6bd54dd4eb06f21693925cdf80f9b8b"
+checksum = "01227be5826fa0690321a2ba6c5cd57a19cf3f6a09e76973b58e61de6ab9d1c1"
 dependencies = [
  "windows-sys 0.59.0",
 ]
@@ -5775,7 +5835,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -5875,9 +5935,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.11.1"
+version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75da29fe9b9b08fe9d6b22b5b4bcbc75d8db3aa31e639aa56bb62e9d46bfceaf"
+checksum = "ea4a292869320c0272d7bc55a5a6aafaff59b4f63404a003887b679a2e05b4b6"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -5928,7 +5988,7 @@ checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -5939,7 +5999,7 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -5962,7 +6022,7 @@ checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -6016,7 +6076,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.5.0",
+ "indexmap 2.6.0",
  "itoa",
  "ryu",
  "serde",
@@ -6055,6 +6115,15 @@ checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
 dependencies = [
  "digest 0.10.7",
  "keccak",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
 ]
 
 [[package]]
@@ -6100,9 +6169,9 @@ dependencies = [
 
 [[package]]
 name = "simdutf8"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f27f6278552951f1f2b8cf9da965d10969b2efdea95a6ec47987ab46edfe263a"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "simple_asn1"
@@ -6204,7 +6273,7 @@ version = "0.4.5"
 dependencies = [
  "anyhow",
  "candid",
- "clap 4.5.17",
+ "clap 4.5.20",
  "dfx-core",
  "dfx-extensions-utils",
  "fn-error-context",
@@ -6310,9 +6379,6 @@ name = "strum"
 version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
-dependencies = [
- "strum_macros",
-]
 
 [[package]]
 name = "strum_macros"
@@ -6324,7 +6390,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -6352,9 +6418,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.77"
+version = "2.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f35bcdf61fd8e7be6caf75f429fdca8beb3ed76584befb503b1569faee373ed"
+checksum = "89132cd0bf050864e1d38dc3bbc07a0eb8e7530af26344d3d2bbbef83499f590"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6370,7 +6436,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -6434,9 +6500,9 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.12.0"
+version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04cbcdd0c794ebb0d4cf35e88edd2f7d2c4c3e9a5a6dab322839b321c6a87a64"
+checksum = "f0f2c9fc62d0beef6951ccffd757e241266a2c833136efbe35af6cd2567dca5b"
 dependencies = [
  "cfg-if",
  "fastrand 2.1.1",
@@ -6479,22 +6545,22 @@ checksum = "23d434d3f8967a09480fb04132ebe0a3e088c173e6d0ee7897abbdf4eab0f8b9"
 
 [[package]]
 name = "thiserror"
-version = "1.0.63"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
+checksum = "d50af8abc119fb8bb6dbabcfa89656f46f84aa0ac7688088608076ad2b459a84"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.63"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
+checksum = "08904e7672f5eb876eaaf87e0ce17857500934f4981c4a0ab2b4aa98baac7fc3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -6604,7 +6670,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -6644,7 +6710,7 @@ version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
 dependencies = [
- "rustls 0.23.13",
+ "rustls 0.23.14",
  "rustls-pki-types",
  "tokio",
 ]
@@ -6695,20 +6761,20 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.5.0",
+ "indexmap 2.6.0",
  "toml_datetime",
  "winnow 0.5.40",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.22.20"
+version = "0.22.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "583c44c02ad26b0c3f3066fe629275e50627026c51ac2e595cca4c230ce1ce1d"
+checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
 dependencies = [
- "indexmap 2.5.0",
+ "indexmap 2.6.0",
  "toml_datetime",
- "winnow 0.6.18",
+ "winnow 0.6.20",
 ]
 
 [[package]]
@@ -6717,11 +6783,6 @@ version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
 dependencies = [
- "futures-core",
- "futures-util",
- "pin-project",
- "pin-project-lite",
- "tokio",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -6747,7 +6808,31 @@ checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
 dependencies = [
  "log",
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-appender"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3566e8ce28cc0a3fe42519fc80e6b4c943cc4c8cef275620eb8dac2d3d4e06cf"
+dependencies = [
+ "crossbeam-channel",
+ "thiserror",
+ "time",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -6757,6 +6842,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-serde"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc6b213177105856957181934e4920de57730fc69bf42c37ee5bb664d406d9e1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]
@@ -6788,9 +6916,9 @@ checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "ucd-trie"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "unicase"
@@ -6803,9 +6931,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.15"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75"
+checksum = "5ab17db44d7388991a428b2ee655ce0c212e862eff1768a455c58f9aad6e7893"
 
 [[package]]
 name = "unicode-ident"
@@ -6815,24 +6943,24 @@ checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.23"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a56d1686db2308d901306f92a263857ef59ea39678a5458e7cb17f01415101f5"
+checksum = "5033c97c4262335cded6d6fc3e5c18ab755e1a3dc96376350f3d8e9f009ad956"
 dependencies = [
  "tinyvec",
 ]
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.13"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0336d538f7abc86d282a4189614dfaa90810dfc2c6f6427eaf88e16311dd225d"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "universal-hash"
@@ -6893,6 +7021,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81dfa00651efa65069b0b6b651f4aaa31ba9e3c3ce0137aaad053604ee7e0314"
 
 [[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+
+[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6912,9 +7046,9 @@ checksum = "317211a0dc0ceedd78fb2ca9a44aed3d7b9b26f81870d485c07122b4350673b7"
 
 [[package]]
 name = "walrus"
-version = "0.21.2"
+version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "160c3708e3ad718ab4d84bec8de8c3d3450cd2902bd6c3ee3bbf50ad7529c2ad"
+checksum = "501ace8ec3492754a9b3c4b59eac7159ceff8414f9e43a05029fe8ef43b9218f"
 dependencies = [
  "anyhow",
  "gimli 0.26.2",
@@ -6975,7 +7109,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
  "wasm-bindgen-shared",
 ]
 
@@ -7009,7 +7143,7 @@ checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -7031,9 +7165,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-streams"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b65dc4c90b63b118468cf747d8bf3566c1913ef60be765b5730ead9e0a3ba129"
+checksum = "4e072d4e72f700fb3443d8fe94a39315df013eef1104903cdb0a2abd322bbecd"
 dependencies = [
  "futures-util",
  "js-sys",
@@ -7051,7 +7185,7 @@ dependencies = [
  "ahash 0.8.11",
  "bitflags 2.6.0",
  "hashbrown 0.14.5",
- "indexmap 2.5.0",
+ "indexmap 2.6.0",
  "semver",
  "serde",
 ]
@@ -7093,9 +7227,9 @@ checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "webpki-roots"
-version = "0.26.5"
+version = "0.26.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bd24728e5af82c6c4ec1b66ac4844bdf8156257fccda846ec58b42cd0cdbe6a"
+checksum = "841c67bff177718f1d4dfefde8d8f0e78f9b6589319ba88312f567fc5841a958"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -7329,9 +7463,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.6.18"
+version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68a9bda4691f099d435ad181000724da8e5899daa10713c2d432552b9ccd3a6f"
+checksum = "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b"
 dependencies = [
  "memchr",
 ]
@@ -7386,6 +7520,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
 
 [[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
+
+[[package]]
 name = "zbus"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7438,7 +7578,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]
@@ -7458,7 +7598,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.79",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,11 +34,11 @@ slog = "^2.7.0"
 tempfile = "3.12.0"
 tokio = { version = "^1.36.0", features = ["rt-multi-thread"] }
 url = "^2.4.1"
-ic-http-utils = { git = "https://github.com/dfinity/ic", rev = "f7e561c00a2745f946372f5166fd7968fa664f53" }
-ic-icp-index = { git = "https://github.com/dfinity/ic", rev = "f7e561c00a2745f946372f5166fd7968fa664f53" }
-ic-icrc1-index-ng = { git = "https://github.com/dfinity/ic", rev = "f7e561c00a2745f946372f5166fd7968fa664f53" }
-ic-icrc1-ledger = { git = "https://github.com/dfinity/ic", rev = "f7e561c00a2745f946372f5166fd7968fa664f53" }
-ic-sns-cli = { git = "https://github.com/dfinity/ic", rev = "f7e561c00a2745f946372f5166fd7968fa664f53" }
+ic-http-utils = { git = "https://github.com/dfinity/ic", rev = "61f05b60fb3464cec774da4dc81aca0dc4fa8366" }
+ic-icp-index = { git = "https://github.com/dfinity/ic", rev = "61f05b60fb3464cec774da4dc81aca0dc4fa8366" }
+ic-icrc1-index-ng = { git = "https://github.com/dfinity/ic", rev = "61f05b60fb3464cec774da4dc81aca0dc4fa8366" }
+ic-icrc1-ledger = { git = "https://github.com/dfinity/ic", rev = "61f05b60fb3464cec774da4dc81aca0dc4fa8366" }
+ic-sns-cli = { git = "https://github.com/dfinity/ic", rev = "61f05b60fb3464cec774da4dc81aca0dc4fa8366" }
 serde_json = "1.0.79"
 
 # Config for 'cargo dist'

--- a/extensions/nns/build.rs
+++ b/extensions/nns/build.rs
@@ -1,7 +1,7 @@
 use std::env;
 use std::path::PathBuf;
 
-const REPLICA_REV: &str = "f7e561c00a2745f946372f5166fd7968fa664f53";
+const REPLICA_REV: &str = "61f05b60fb3464cec774da4dc81aca0dc4fa8366";
 
 const BINARY_DEPENDENCIES: &[(&str, &str)] = &[
     // (downloaded binary name, renamed binary name)

--- a/extensions/sns/README.md
+++ b/extensions/sns/README.md
@@ -17,6 +17,7 @@ Depending on the `dfx sns` subcommand you specify, additional arguments, options
 | [`propose`](#_dfx_sns_propose)                                     | Submits a CreateServiceNervousSystem NNS Proposal.                                                                 |
 | [`neuron-id-to-candid-subaccount`](#_dfx_sns_propose)              | Converts a Neuron ID to a candid subaccount blob suitable for use in the `manage_neuron` method on SNS Governance. |
 | [`list`](#_list)                                                   | Lists SNSes and their canister IDs.                                                                                |
+| [`health`](#_health)                                               | Lists SNSes and does basic checks of their memory, cycles, and version.                                            |
 | `help`                                                             | Displays usage information message for a specified subcommand.                                                     |
 
 To view usage information for a specific subcommand, specify the subcommand and the `--help` flag. For example, to see usage information for `dfx sns validate`, you can run the following command:
@@ -110,7 +111,11 @@ dfx sns propose --test-neuron-proposer sns_init.yaml
 
 ## dfx sns list
 
-Use the `dfx sns list` command to see all the SNSes and their canister IDs. You can also pass --json to get this information in json format rather than a human-readable table.
+Use the `dfx sns list` command to see all the SNSes and their canister IDs. You can also pass `--json` to get this information in json format rather than a human-readable table.
+
+## dfx sns health
+
+Use the `dfx sns health` command to see the health of all SNSes. You can also pass `--json` to get this information in json format rather than a human-readable table. By default, dapp canisters are not examined. You can include them with the `--include-dapps` subcommand.
 
 ### Basic usage
 

--- a/extensions/sns/build.rs
+++ b/extensions/sns/build.rs
@@ -1,7 +1,7 @@
 use std::env;
 use std::path::PathBuf;
 
-const REPLICA_REV: &str = "f7e561c00a2745f946372f5166fd7968fa664f53";
+const REPLICA_REV: &str = "61f05b60fb3464cec774da4dc81aca0dc4fa8366";
 
 const BINARY_DEPENDENCIES: &[(&str, &str)] = &[
     // (downloaded binary name, renamed binary name)

--- a/extensions/sns/extension.json
+++ b/extensions/sns/extension.json
@@ -124,6 +124,26 @@
       },
       "subcommands": null
     },
+    "health": {
+      "about": "Report health of SNSes",
+      "args": {
+        "include_dapps": {
+          "about": "Includes dapp canisters in the output",
+          "long": "include-dapps",
+          "short": null,
+          "multiple": false,
+          "values": 0
+        },
+        "json": {
+          "about": "Output the SNS information as JSON (instead of a human-friendly table)",
+          "long": "json",
+          "short": null,
+          "multiple": false,
+          "values": 0
+        }
+      },
+      "subcommands": null
+    },
     "import": {
       "about": "Subcommand for importing sns API definitions and canister IDs. This and `Download` are only useful for SNS testflight",
       "args": {
@@ -288,5 +308,6 @@
   "dependencies": {
     "dfx": ">=0.17.0"
   },
-  "canister_type": null
+  "canister_type": null,
+  "download_url_template": "https://github.com/dfinity/dfx-extensions/releases/download/{{tag}}/{{basename}}.{{archive-format}}"
 }

--- a/extensions/sns/src/main.rs
+++ b/extensions/sns/src/main.rs
@@ -16,6 +16,7 @@ use ic_sns_cli::{
     add_sns_wasm_for_tests, deploy_testflight,
     init_config_file::{self, InitConfigFileArgs},
     list::{self, ListArgs},
+    health::{self, HealthArgs},
     neuron_id_to_candid_subaccount::{self, NeuronIdToCandidSubaccountArgs},
     prepare_canisters::{self, PrepareCanistersArgs},
     propose::{self, ProposeArgs},
@@ -65,6 +66,8 @@ enum SubCommand {
     AddSnsWasmForTests(AddSnsWasmForTestsArgs),
     /// List SNSes
     List(ListArgs),
+    /// Report health of SNSes
+    Health(HealthArgs),
 
     /// Subcommand for importing sns API definitions and canister IDs.
     /// This and `Download` are only useful for SNS testflight
@@ -96,6 +99,7 @@ async fn main() -> anyhow::Result<()> {
         }
         SubCommand::AddSnsWasmForTests(args) => SnsLibSubCommand::AddSnsWasmForTests(args),
         SubCommand::List(args) => SnsLibSubCommand::List(args),
+        SubCommand::Health(args) => SnsLibSubCommand::Health(args),
 
         SubCommand::Import(v) => {
             let dfx_cache_path = &opts.dfx_cache_path.ok_or_else(|| {
@@ -127,6 +131,7 @@ async fn main() -> anyhow::Result<()> {
         }
         SnsLibSubCommand::AddSnsWasmForTests(args) => add_sns_wasm_for_tests(args),
         SnsLibSubCommand::List(args) => list::exec(args, &agent).await,
+        SnsLibSubCommand::Health(args) => health::exec(args, &agent).await,
     }
 }
 


### PR DESCRIPTION
Use the `dfx sns health` command to see the health of all SNSes. You can also pass `--json` to get this information in json format rather than a human-readable table. By default, dapp canisters are not examined. You can include them with the `--include-dapps` subcommand.

This command is implemented in the IC monorepo, so all that is required of the extension is to call the appropriate function in the monorepo.