### PR TITLE
feat: support application subnets for PocketIC

### DIFF
--- a/extensions/nns/CHANGELOG.md
+++ b/extensions/nns/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased] - ReleaseDate
 - Fixed a bug where `dfx nns install` and `dfx nns import` would fail if a canister type in dfx.json was defined by an extension.
+- Added support for application subnets for `dfx start --pocketic`.
 
 ## [0.4.7] - 2024-11-08
 - Added support for `dfx start --pocketic`.

--- a/extensions/nns/e2e/assets/subnet_type/shared_network_settings/application/networks.json
+++ b/extensions/nns/e2e/assets/subnet_type/shared_network_settings/application/networks.json
@@ -1,0 +1,7 @@
+{
+    "local": {
+        "replica": {
+            "subnet_type": "application"
+        }
+    }
+}

--- a/extensions/nns/e2e/tests/nns.bash
+++ b/extensions/nns/e2e/tests/nns.bash
@@ -91,6 +91,22 @@ assert_nns_canister_id_matches() {
     #assert_nns_canister_id_matches nns-dapp
 }
 
+@test "dfx nns install on application subnet" {
+    echo Setting up...
+    install_shared_asset subnet_type/shared_network_settings/application
+    dfx_start_for_nns_install
+
+    run dfx nns install
+
+    if [[ "$USE_POCKET_IC" ]]
+    then
+      assert_success
+    else
+      assert_failure
+      assert_output --partial "The replica subnet_type needs to be 'system' to run NNS canisters."
+    fi
+}
+
 @test "dfx nns install runs" {
 
     echo Setting up...

--- a/extensions/sns/src/main.rs
+++ b/extensions/sns/src/main.rs
@@ -14,9 +14,9 @@ use crate::commands::{download::SnsDownloadOpts, import::SnsImportOpts};
 use clap::Parser;
 use ic_sns_cli::{
     add_sns_wasm_for_tests, deploy_testflight,
+    health::{self, HealthArgs},
     init_config_file::{self, InitConfigFileArgs},
     list::{self, ListArgs},
-    health::{self, HealthArgs},
     neuron_id_to_candid_subaccount::{self, NeuronIdToCandidSubaccountArgs},
     prepare_canisters::{self, PrepareCanistersArgs},
     propose::{self, ProposeArgs},


### PR DESCRIPTION
This PR adds support for application subnets when using `dfx start --pocketic`.