### PR TITLE
feat: configure PocketIC SNS and PocketIC default subnet in NNS canisters

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Install IC SDK (dfx)
         uses: dfinity/setup-dfx@main
         with:
-          dfx-version: "0.24.1"
+          dfx-version: "0.24.2"
       - name: Set prebuilt extensions directory
         run: echo "PREBUILT_EXTENSIONS_DIR=$HOME/prebuilt-extensions" >> $GITHUB_ENV
       - name: Build extension manually

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3009,7 +3009,7 @@ dependencies = [
  "ic-sns-root",
  "ic-sns-swap",
  "ic-sns-wasm",
- "pocket-ic",
+ "pocket-ic 5.0.0",
  "serde",
  "tempfile",
  "thiserror",
@@ -4614,6 +4614,7 @@ dependencies = [
  "ic-icrc1-ledger",
  "ic-sns-cli",
  "ic-utils 0.38.0",
+ "pocket-ic 6.0.0",
  "reqwest 0.11.27",
  "rust_decimal",
  "serde",
@@ -5048,6 +5049,35 @@ checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
 name = "pocket-ic"
 version = "5.0.0"
 source = "git+https://github.com/dfinity/ic?rev=0f96a6f4661f0d87bd9149a88846db9674360291#0f96a6f4661f0d87bd9149a88846db9674360291"
+dependencies = [
+ "base64 0.13.1",
+ "candid",
+ "hex",
+ "ic-certification",
+ "ic-transport-types 0.37.1",
+ "reqwest 0.12.9",
+ "schemars",
+ "serde",
+ "serde_bytes",
+ "serde_cbor",
+ "serde_json",
+ "sha2 0.10.8",
+ "slog",
+ "strum",
+ "strum_macros",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "tracing-appender",
+ "tracing-subscriber",
+ "wslpath",
+]
+
+[[package]]
+name = "pocket-ic"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "124a2380ca6f557adf8b02517cbfd2f564113230e14cda6f6aadd3dfe156293c"
 dependencies = [
  "base64 0.13.1",
  "candid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ fn-error-context = "0.2.1"
 futures-util = "0.3.28"
 ic-agent = "=0.38.0"
 ic-utils = "=0.38.0"
+pocket-ic = "6.0.0"
 reqwest = { version = "^0.11.22", default-features = false, features = [
     "blocking",
     "json",

--- a/extensions/nns/CHANGELOG.md
+++ b/extensions/nns/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased] - ReleaseDate
 - Fixed a bug where `dfx nns install` and `dfx nns import` would fail if a canister type in dfx.json was defined by an extension.
 - Added support for application subnets for `dfx start --pocketic`.
+- Configure the PocketIC SNS subnet in the SNS-W canister and the default subnet in the CMC canister.
 
 ## [0.4.7] - 2024-11-08
 - Added support for `dfx start --pocketic`.

--- a/extensions/nns/Cargo.toml
+++ b/extensions/nns/Cargo.toml
@@ -30,6 +30,7 @@ ic-icrc1-index-ng.workspace = true
 ic-icrc1-ledger.workspace = true
 ic-http-utils.workspace = true
 hex = "0.4.3"
+pocket-ic.workspace = true
 reqwest.workspace = true
 rust_decimal = "1.29.1"
 serde.workspace = true

--- a/extensions/nns/e2e/tests/nns.bash
+++ b/extensions/nns/e2e/tests/nns.bash
@@ -118,6 +118,10 @@ assert_nns_canister_id_matches() {
         echo "No application subnet found in the PocketIC instance topology."
         exit 1
       fi
+      while [[ "$(dfx canister call rkp4c-7iaaa-aaaaa-aaaca-cai get_default_subnets '()' --query | grep "${APP_SUBNET_ID}")" == "" ]]
+      do
+        sleep 1
+      done
       run dfx canister call rkp4c-7iaaa-aaaaa-aaaca-cai get_default_subnets '()' --query
       assert_success
       assert_output --partial "${APP_SUBNET_ID}"

--- a/extensions/nns/e2e/tests/nns.bash
+++ b/extensions/nns/e2e/tests/nns.bash
@@ -101,6 +101,26 @@ assert_nns_canister_id_matches() {
     if [[ "$USE_POCKET_IC" ]]
     then
       assert_success
+
+      SNS_SUBNET_ID=$(curl http://localhost:8080/_/topology | jq -r '.subnet_configs | map_values(select(.subnet_kind=="SNS")) | keys[]')
+      if [[ "${SNS_SUBNET_ID}" == "" ]]
+      then
+        echo "No SNS subnet found in the PocketIC instance topology."
+        exit 1
+      fi
+      run dfx canister call qaa6y-5yaaa-aaaaa-aaafa-cai get_sns_subnet_ids '(record {})' --query
+      assert_success
+      assert_output --partial "${SNS_SUBNET_ID}"
+
+      APP_SUBNET_ID=$(curl http://localhost:8080/_/topology | jq -r '.subnet_configs | map_values(select(.subnet_kind=="Application")) | keys[]')
+      if [[ "${APP_SUBNET_ID}" == "" ]]
+      then
+        echo "No application subnet found in the PocketIC instance topology."
+        exit 1
+      fi
+      run dfx canister call rkp4c-7iaaa-aaaaa-aaaca-cai get_default_subnets '()' --query
+      assert_success
+      assert_output --partial "${APP_SUBNET_ID}"
     else
       assert_failure
       assert_output --partial "The replica subnet_type needs to be 'system' to run NNS canisters."

--- a/extensions/nns/e2e/tests/nns.bash
+++ b/extensions/nns/e2e/tests/nns.bash
@@ -205,12 +205,7 @@ assert_nns_canister_id_matches() {
     run dfx --identity ident-1 canister call rkp4c-7iaaa-aaaaa-aaaca-cai notify_mint_cycles '(record { block_index = 5 : nat64; })'
     # If cycles ledger is configured correctly, then notify_mint_cycles will try to call the cycles ledger (and fail because the canister is not even created).
     # If it is not configured correctly, then this will complain about the cycles ledger canister id not being configured.
-    if [ "$USE_POCKET_IC" ]
-    then
-      assert_output --partial "No route to canister um5iw-rqaaa-aaaaq-qaaba-cai"
-    else
-      assert_output --partial "Canister um5iw-rqaaa-aaaaq-qaaba-cai not found"
-    fi
+    assert_output --partial "Canister um5iw-rqaaa-aaaaq-qaaba-cai not found"
 }
 
 @test "dfx nns install with a canister type defined by another extension" {


### PR DESCRIPTION
This PR sonfigures the PocketIC SNS subnet in the SNS-W canister and the PocketIC default subnet in the CMC canister by reading the subnet IDs from the PocketIC topology.