### PR TITLE
fix: do not submit invalid NNS proposal to set cycles ledger in CMC

### DIFF
--- a/extensions/nns/src/install_nns.rs
+++ b/extensions/nns/src/install_nns.rs
@@ -11,8 +11,7 @@ use dfx_core::config::model::dfinity::{NetworksConfig, ReplicaSubnetType};
 use dfx_core::config::model::network_descriptor::NetworkDescriptor;
 use dfx_core::identity::CallSender;
 use dfx_extensions_utils::dependencies::download_wasms::nns::{
-    CYCLES_LEDGER, ICP_INDEX, ICRC1_INDEX, ICRC1_LEDGER, INTERNET_IDENTITY, NNS_CYCLES_MINTING,
-    NNS_DAPP, NNS_LEDGER, SNS_AGGREGATOR,
+    ICP_INDEX, ICRC1_INDEX, ICRC1_LEDGER, INTERNET_IDENTITY, NNS_DAPP, NNS_LEDGER, SNS_AGGREGATOR,
 };
 use dfx_extensions_utils::{
     call_extension_bundled_binary, download_nns_wasms, nns_wasm_dir, IcNnsInitCanister,
@@ -37,7 +36,6 @@ use ic_utils::interfaces::ManagementCanister;
 use pocket_ic::common::rest::Topology;
 use reqwest::Url;
 use serde::Serialize;
-use sha2::{Digest, Sha256};
 use slog::Logger;
 use std::ffi::OsString;
 use std::fs;
@@ -259,7 +257,6 @@ pub async fn install_nns(
     eprintln!("Configuring the NNS...");
     set_xdr_rate(1234567, &nns_url, dfx_cache_path)?;
     set_cmc_authorized_subnets(&nns_url, &default_subnet_id.to_string(), dfx_cache_path)?;
-    set_cycles_ledger_canister_id_in_cmc(&nns_url, dfx_cache_path)?;
 
     print_nns_details(provider_url)?;
     Ok(())
@@ -632,61 +629,6 @@ pub fn set_cmc_authorized_subnets(
     ];
     call_extension_bundled_binary("ic-admin", args, dfx_cache_path)
         .map_err(|e| anyhow!("Call to propose to set authorized subnets failed: {e}"))
-}
-
-/// Sets the cycles ledger canister id in the CMC
-#[context("Failed to set the cycles ledger canister id in the CMC")]
-pub fn set_cycles_ledger_canister_id_in_cmc(
-    nns_url: &Url,
-    dfx_cache_path: &Path,
-) -> anyhow::Result<()> {
-    #[derive(CandidType, Clone, Debug, PartialEq, Eq)]
-    struct CyclesCanisterInitPayload {
-        pub cycles_ledger_canister_id: Option<Principal>,
-    }
-
-    let wasm_path = nns_wasm_dir(dfx_cache_path);
-    let cmc_wasm_path = wasm_path.join(NNS_CYCLES_MINTING.wasm_name);
-    let cmc_wasm_bytes = dfx_core::fs::read(&cmc_wasm_path)?;
-    let wasm_hash = Sha256::digest(cmc_wasm_bytes);
-    let upgrade_arg = format!(
-        "(opt record {{ cycles_ledger_canister_id = opt principal \"{}\" }})",
-        CYCLES_LEDGER.canister_id
-    );
-    let mut upgrade_arg_file = tempfile::NamedTempFile::new()?;
-    upgrade_arg_file
-        .write_all(upgrade_arg.as_bytes())
-        .context("Failed to write to tempfile.")?;
-
-    let cmc_wasm_path_str = cmc_wasm_path.to_string_lossy();
-    let wasm_hash_str = hex::encode(wasm_hash);
-    let upgrade_arg_file_str = upgrade_arg_file.path().to_string_lossy();
-    let upgrade_arg_hash =
-        ic_http_utils::file_downloader::compute_sha256_hex(&upgrade_arg_file.path())?;
-    let args = vec![
-        "--nns-url",
-        nns_url.as_str(),
-        "propose-to-change-nns-canister",
-        "--test-neuron-proposer",
-        "--proposal-title",
-        "Set cycles ledger canister id in Cycles Minting Canister",
-        "--summary",
-        "Set cycles ledger canister id in Cycles Minting Canister",
-        "--mode",
-        "upgrade",
-        "--canister-id",
-        NNS_CYCLES_MINTING.canister_id,
-        "--wasm-module-path",
-        &cmc_wasm_path_str,
-        "--wasm-module-sha256",
-        &wasm_hash_str,
-        "--arg",
-        &upgrade_arg_file_str,
-        "--arg-sha256",
-        &upgrade_arg_hash,
-    ];
-    call_extension_bundled_binary("ic-admin", args, dfx_cache_path)
-        .map_err(|e| anyhow!("Call to set the cycles ledger canister id in the CMC: {e}"))
 }
 
 /// Uploads wasms to the nns-sns-wasm canister.


### PR DESCRIPTION
This PR removes logic to set the cycles ledger canister ID in CMC by upgrading CMC because that logic was incorrect: it passed the install argument in textual form (instead of its binary encoding) which couldn't be parsed by CMC:
```
2025-01-06 08:47:46.697067178 UTC: [Canister r7inp-6aaaa-aaaaa-aaabq-cai] [Root Canister] change_canister: Canister change failed: Attempt to call install_code with request ChangeCanisterRequest { stop_before_installing: true, mode: Upgrade, canister_id: CanisterId(rkp4c-7iaaa-aaaaa-aaaca-cai), wasm_module_sha256: "[de, 3d, 29, 97, b5, 6f, f8, b3, d, 80, 20, ac, 9e, 24, 37, bc, e3, a8, 99, 88, d6, bc, 5b, 69, 59, c5, f, 81, 29, 6b, 7b, 7e]", arg_sha256: "[5, c5, db, 83, 70, 35, 2c, 62, 2d, ef, f3, a2, 49, de, d6, e3, 55, 61, 2c, 3, 92, 8f, f6, 42, 18, 31, 87, ca, 80, 36, 4a, 13]", compute_allocation: None, memory_allocation: None } failed with code CanisterError: Error from Canister rkp4c-7iaaa-aaaaa-aaaca-cai: Canister called `ic0.trap` with message: Panicked at 'Deserialization Failed: "Cannot parse header 286f7074207265636f7264207b206379636c65735f6c65646765725f63616e69737465725f6964203d206f7074207072696e636970616c2022756d3569772d72716161612d61616161712d71616162612d63616922207d29"', rs/rust_canisters/dfn_core/src/endpoint.rs:49:41
Canister Backtrace:
unknown function at index 1399
unknown function at index 744
unknown function at index 1030
unknown function at index 1052
unknown function at index 1534
unknown function at index 1143
unknown function at index 1150
unknown function at index 1071
unknown function at index 89
```
where the header `286f7074207265636f7264207b206379636c65735f6c65646765725f63616e69737465725f6964203d206f7074207072696e636970616c2022756d3569772d72716161612d61616161712d71616162612d63616922207d29` is the hex encoding of the string `(opt record { cycles_ledger_canister_id = opt principal "um5iw-rqaaa-aaaaq-qaaba-cai" })`.

This logic can be removed since the cycles ledger canister ID is already set in CMC when its initialized:
```
2025-01-06 08:46:51.976270215 UTC: [Canister rkp4c-7iaaa-aaaaa-aaaca-cai] [cycles] init() with ledger canister ryjl3-tyaaa-aaaaa-aaaba-cai, governance canister rrkah-fqaaa-aaaaa-aaaaq-cai, exchange rate canister <none>, minting account 082ecf2e3f647ac600f43f38a68342fba5b8e68b085f02592b77f39808a8d2b5, and cycles ledger canister um5iw-rqaaa-aaaaq-qaaba-cai
```