### PR TITLE
Use the same replica rev for NNS/SNS extension binaries/wasms

### DIFF
--- a/extensions-utils/src/dependencies/dfx.rs
+++ b/extensions-utils/src/dependencies/dfx.rs
@@ -6,6 +6,9 @@ use std::ffi::OsStr;
 use std::path::Path;
 use std::process::Command;
 
+/// The replica revision of the NNS/SNS canisters which might have dependencies among each other.
+pub const NNS_SNS_REPLICA_REV: &str = "760e1f764b56f4f655a09789c245da487eccc5cb";
+
 /// Calls a binary from dfx cache.
 ///
 /// # Returns
@@ -25,27 +28,6 @@ where
 {
     let binary = dfx_cache_path.join(command);
     execute_command(&binary, args, dfx_cache_path)
-}
-
-pub fn replica_rev(dfx_cache_path: &Path) -> Result<String, DfxError> {
-    let args = ["info", "replica-rev"];
-    let rev = Command::new(dfx_cache_path.join("dfx"))
-        .args(args)
-        .output()
-        .map_err(DfxError::DfxExecutableError)?
-        .stdout
-        .iter()
-        .map(|c| *c as char)
-        .collect::<String>()
-        .trim()
-        .to_string();
-    if rev.len() != 40 {
-        return Err(DfxError::MalformedCommandOutput {
-            command: args.join(" ").to_string(),
-            output: rev,
-        });
-    }
-    Ok(rev)
 }
 
 pub fn dfx_version(dfx_cache_path: &Path) -> Result<String, DfxError> {

--- a/extensions-utils/src/dependencies/dfx.rs
+++ b/extensions-utils/src/dependencies/dfx.rs
@@ -7,7 +7,7 @@ use std::path::Path;
 use std::process::Command;
 
 /// The replica revision of the NNS/SNS canisters which might have dependencies among each other.
-pub const NNS_SNS_REPLICA_REV: &str = "760e1f764b56f4f655a09789c245da487eccc5cb";
+pub const NNS_SNS_REPLICA_REV: &str = "5ebf5a3922383cbb937d0fbc0509aec445341036";
 
 /// Calls a binary from dfx cache.
 ///

--- a/extensions-utils/src/dependencies/download_wasms/nns.rs
+++ b/extensions-utils/src/dependencies/download_wasms/nns.rs
@@ -4,18 +4,14 @@ use std::path::{Path, PathBuf};
 
 use fn_error_context::context;
 
-use crate::{download_ic_repo_wasm, replica_rev};
+use crate::{dependencies::dfx::NNS_SNS_REPLICA_REV, download_ic_repo_wasm};
 
 use super::sns::download_sns_wasms;
 
 /// Downloads all the core NNS wasms, excluding only the front-end wasms II and NNS-dapp.
 #[context("Failed to download NNS wasm files.")]
 pub async fn download_nns_wasms(dfx_cache_path: &Path) -> anyhow::Result<()> {
-    let ic_commit = if let Ok(env_ic_commit) = std::env::var("DFX_IC_COMMIT") {
-        env_ic_commit
-    } else {
-        replica_rev(dfx_cache_path)?
-    };
+    let ic_commit = std::env::var("DFX_IC_COMMIT").unwrap_or(NNS_SNS_REPLICA_REV.to_string());
     let wasm_dir = &nns_wasm_dir(dfx_cache_path);
     for IcNnsInitCanister {
         wasm_name,

--- a/extensions-utils/src/lib.rs
+++ b/extensions-utils/src/lib.rs
@@ -8,7 +8,7 @@ mod project;
 
 pub use dependencies::{
     call::call_extension_bundled_binary,
-    dfx::{call_dfx_bundled_binary, dfx_version, replica_rev},
+    dfx::{call_dfx_bundled_binary, dfx_version},
     download_ic_binaries::download_ic_binary,
     download_wasms::{
         download_ic_repo_wasm,

--- a/extensions/nns/build.rs
+++ b/extensions/nns/build.rs
@@ -1,7 +1,6 @@
+use dfx_extensions_utils::dependencies::dfx::NNS_SNS_REPLICA_REV;
 use std::env;
 use std::path::PathBuf;
-
-const REPLICA_REV: &str = "760e1f764b56f4f655a09789c245da487eccc5cb";
 
 const BINARY_DEPENDENCIES: &[(&str, &str)] = &[
     // (downloaded binary name, renamed binary name)
@@ -26,7 +25,11 @@ fn main() {
         let bin_in_manifest_dir = manifest_dir.join(renamed_binary_name);
         let bin_in_target_dir = target_dir.join(renamed_binary_name);
         dbg!(&bin_in_manifest_dir, &bin_in_target_dir);
-        dfx_extensions_utils::download_ic_binary(REPLICA_REV, binary_name, &bin_in_manifest_dir);
+        dfx_extensions_utils::download_ic_binary(
+            NNS_SNS_REPLICA_REV,
+            binary_name,
+            &bin_in_manifest_dir,
+        );
         if bin_in_target_dir.exists() {
             std::fs::remove_file(&bin_in_target_dir).unwrap();
         }

--- a/extensions/nns/src/commands/import.rs
+++ b/extensions/nns/src/commands/import.rs
@@ -6,8 +6,9 @@ use dfx_core::config::model::canister_id_store::CanisterIds;
 use dfx_core::config::model::dfinity::Config;
 use dfx_core::extension::manager::ExtensionManager;
 use dfx_extensions_utils::{
-    get_canisters_json_object, get_network_mappings, import_canister_definitions, new_logger,
-    replica_rev, set_remote_canister_ids, ImportNetworkMapping, NNS_CORE,
+    dependencies::dfx::NNS_SNS_REPLICA_REV, get_canisters_json_object, get_network_mappings,
+    import_canister_definitions, new_logger, set_remote_canister_ids, ImportNetworkMapping,
+    NNS_CORE,
 };
 
 use clap::Parser;
@@ -38,11 +39,7 @@ pub async fn exec(opts: ImportOpts, dfx_cache_path: &Path) -> anyhow::Result<()>
     let logger = new_logger();
 
     let network_mappings = get_network_mappings(&opts.network_mapping)?;
-    let ic_commit = if let Ok(env_ic_commit) = std::env::var("DFX_IC_COMMIT") {
-        env_ic_commit
-    } else {
-        replica_rev(dfx_cache_path)?
-    };
+    let ic_commit = std::env::var("DFX_IC_COMMIT").unwrap_or(NNS_SNS_REPLICA_REV.to_string());
     let dfx_url_str = {
         let ic_project = std::env::var("DFX_IC_SRC").unwrap_or_else(|_| {
             format!("https://raw.githubusercontent.com/dfinity/ic/{ic_commit}")

--- a/extensions/sns/build.rs
+++ b/extensions/sns/build.rs
@@ -1,7 +1,6 @@
+use dfx_extensions_utils::dependencies::dfx::NNS_SNS_REPLICA_REV;
 use std::env;
 use std::path::PathBuf;
-
-const REPLICA_REV: &str = "760e1f764b56f4f655a09789c245da487eccc5cb";
 
 const BINARY_DEPENDENCIES: &[(&str, &str)] = &[
     // (downloaded binary name, renamed binary name)
@@ -24,7 +23,11 @@ fn main() {
         let bin_in_manifest_dir = manifest_dir.join(renamed_binary_name);
         let bin_in_target_dir = target_dir.join(renamed_binary_name);
         dbg!(&bin_in_manifest_dir, &bin_in_target_dir);
-        dfx_extensions_utils::download_ic_binary(REPLICA_REV, binary_name, &bin_in_manifest_dir);
+        dfx_extensions_utils::download_ic_binary(
+            NNS_SNS_REPLICA_REV,
+            binary_name,
+            &bin_in_manifest_dir,
+        );
         if bin_in_target_dir.exists() {
             std::fs::remove_file(&bin_in_target_dir).unwrap();
         }

--- a/extensions/sns/src/commands/download.rs
+++ b/extensions/sns/src/commands/download.rs
@@ -1,8 +1,6 @@
 //! Code for the command line `dfx sns import`
-use dfx_extensions_utils::download_sns_wasms;
-use dfx_extensions_utils::replica_rev;
-
 use clap::Parser;
+use dfx_extensions_utils::{dependencies::dfx::NNS_SNS_REPLICA_REV, download_sns_wasms};
 use std::path::{Path, PathBuf};
 
 /// Downloads the SNS canister WASMs
@@ -17,12 +15,8 @@ pub struct SnsDownloadOpts {
 }
 
 /// Executes the command line `dfx sns import`.
-pub async fn exec(opts: SnsDownloadOpts, dfx_cache_path: &Path) -> anyhow::Result<()> {
-    let ic_commit = if let Some(ic_commit) = opts.ic_commit {
-        ic_commit
-    } else {
-        replica_rev(dfx_cache_path)?
-    };
+pub async fn exec(opts: SnsDownloadOpts) -> anyhow::Result<()> {
+    let ic_commit = opts.ic_commit.unwrap_or(NNS_SNS_REPLICA_REV.to_string());
     download_sns_wasms(&ic_commit, &opts.wasms_dir).await?;
     Ok(())
 }

--- a/extensions/sns/src/commands/import.rs
+++ b/extensions/sns/src/commands/import.rs
@@ -2,9 +2,8 @@
 use std::path::Path;
 
 use dfx_core::config::model::dfinity::Config;
-use dfx_extensions_utils::{
-    get_network_mappings, import_canister_definitions, new_logger, replica_rev,
-};
+use dfx_extensions_utils::dependencies::dfx::NNS_SNS_REPLICA_REV;
+use dfx_extensions_utils::{get_network_mappings, import_canister_definitions, new_logger};
 
 use clap::Parser;
 use dfx_core::config::cache::get_version_from_cache_path;
@@ -36,11 +35,7 @@ pub async fn exec(opts: SnsImportOpts, dfx_cache_path: &Path) -> anyhow::Result<
 
     let network_mappings = get_network_mappings(&opts.network_mapping)?;
 
-    let ic_commit = if let Ok(v) = std::env::var("DFX_IC_COMMIT") {
-        v
-    } else {
-        replica_rev(dfx_cache_path)?
-    };
+    let ic_commit = std::env::var("DFX_IC_COMMIT").unwrap_or(NNS_SNS_REPLICA_REV.to_string());
     let their_dfx_json_location =
         format!("https://raw.githubusercontent.com/dfinity/ic/{ic_commit}/rs/sns/cli/dfx.json");
     import_canister_definitions(

--- a/extensions/sns/src/main.rs
+++ b/extensions/sns/src/main.rs
@@ -124,7 +124,6 @@ impl NetworkOpt {
     }
 }
 
-
 pub async fn agent(network: NetworkOpt, identity: Option<String>) -> anyhow::Result<Agent> {
     let network = match network.to_network_name() {
         Some(network) => network,
@@ -183,12 +182,7 @@ async fn main() -> anyhow::Result<()> {
             return commands::import::exec(v, dfx_cache_path).await;
         }
         SubCommand::Download(v) => {
-            let dfx_cache_path = &opts.dfx_cache_path.ok_or_else(|| {
-                anyhow::Error::msg(
-                    "Missing path to dfx cache. Pass it as CLI argument: `--dfx-cache-path=PATH`",
-                )
-            })?;
-            return commands::download::exec(v, dfx_cache_path).await;
+            return commands::download::exec(v).await;
         }
     };
 


### PR DESCRIPTION
# Why

The binaries and wasms used by the NNS/SNS extensions are using different versions - the wasms mostly use the `dfx info replica-rev` selected by the dfx release, while the binaries (such as ic_nns_init) are using the hard-coded one. However, there are dependencies among them, and it's difficult to maintain compatibility when they are chosen by disjoint release processes.

# What

* Define a variable `NNS_SNS_REPLICA_REV`
* Replace usage of `replica_rev(dfx_cache_path)` with `NNS_SNS_REPLICA_REV`
* Replace usage of `REPLICA_REV` with `NNS_SNS_REPLICA_REV`
* Update the replica rev to 5ebf5a3922383cbb937d0fbc0509aec445341036 (where the icrc1 ledger index has the correct path)

## Why `NNS_SNS_` prefix

The intention is to make it clear that this git hash is for choosing NNS/SNS binaries/wasms, without precluding the possibility that other extensions might exist. Given that there are other extensions in the foreseeable future, the reason for the prefix isn't that strong.