### PR TITLE
chore: Use ubuntu 22.04 runner for e2e testing

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ macos-14, ubuntu-20.04 ]
+        os: [ macos-14, ubuntu-22.04 ]
         extension: [ nns, sns ]
         pocketic: [ "", "pocketic" ]
     steps:


### PR DESCRIPTION
# Why

The ubuntu-20.04 runner is obsolete: https://github.com/actions/runner-images/issues/11101

# What

Replace "ubuntu-20.04" with "ubuntu-22.04" in e2e.yml