### PR TITLE
chore: Fix CODEOWNERS after renaming from nns-team to governance-team

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @dfinity/sdk @dfinity/nns-team
+* @dfinity/sdk @dfinity/governance-team


### PR DESCRIPTION
dfinity/nns-team is renamed to dfinity/governance-team. Update CODEOWNERS accordingly.