### PR TITLE
chore: Specify the custom runner for x86_64-unknown-linux-gnu too

### DIFF
--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -23,5 +23,8 @@ cargo-dist-version = "0.28.0"
 installers = []
 # Which actions to run on pull requests
 pr-run-mode = "skip"
-# Use custom runners for ubuntu, as the default 20.04 is unsupported
-github-custom-runners = { global = "ubuntu-22.04" }
+# Use custom runners for ubuntu, as the default 20.04 is unsupported. The "global" runner is used
+# for tasks like "plan", "host", "announce" and "build-global-artifacts" that are not specific to a
+# target, and the "x86_64-unknown-linux-gnu" runner is used to build the extensions for the specific
+# target.
+github-custom-runners = { global = "ubuntu-22.04", x86_64-unknown-linux-gnu = "ubuntu-22.04" }


### PR DESCRIPTION
# Why

Previously, only the "global" runner is set to "ubuntu-22.04", while the linux runner is still the default (set by `cargo-dist`) "ubuntu-20.04". 

# How it's tested

Previously, [this job](https://github.com/dfinity/dfx-extensions/actions/runs/15234019319/job/42845503695) runs `dist host --steps=create --tag=nns-v0.5.2 --output-format=json` and its output is incorrect because "ubuntu-20.04" is still specified as the runner for "x86_64-unknown-linux-gnu". With this change, running `dist host --steps=create --tag=nns-v0.5.2 --output-format=json` locally produces the right result - the "x86_64-unknown-linux-gnu" is set to "ubuntu-22.04"