### PR TITLE
fix: Add the network arg into SNS extension json

### DIFF
--- a/extensions/sns/extension.json
+++ b/extensions/sns/extension.json
@@ -140,6 +140,13 @@
           "short": null,
           "multiple": false,
           "values": 0
+        },
+        "network": {
+          "about": "The network to deploy to. This can be \"local\", \"ic\", or the URL of an IC network",
+          "long": "network",
+          "short": null,
+          "multiple": false,
+          "values": 1
         }
       },
       "subcommands": null
@@ -185,6 +192,13 @@
           "short": null,
           "multiple": false,
           "values": 0
+        },
+        "network": {
+          "about": "The network to deploy to. This can be \"local\", \"ic\", or the URL of an IC network",
+          "long": "network",
+          "short": null,
+          "multiple": false,
+          "values": 1
         }
       },
       "subcommands": null
@@ -345,6 +359,13 @@
         "wasm_path": {
           "about": "Path to a ICP WASM module file (may be gzipped)",
           "long": "wasm-path",
+          "short": null,
+          "multiple": false,
+          "values": 1
+        },
+        "network": {
+          "about": "The network to deploy to. This can be \"local\", \"ic\", or the URL of an IC network",
+          "long": "network",
           "short": null,
           "multiple": false,
           "values": 1


### PR DESCRIPTION
`dfx sns ${COMMAND}` uses the extension.json to validate the args. Previously, the `network` arg was missing for several commands even though it's accepted by the extension binary (most likely overlooked as `network` applies to all subcommands). This PR adds the network arg for most of the commands. Note that it's not added for `download`/`import` since they do not interact with the IC network.